### PR TITLE
ci: adding validation checks

### DIFF
--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Validate JSON
         uses: GrantBirki/json-yaml-validate@v2.3.1
         with:
+          base_dir: mainnet
           json_schema: ./schemas/metadata.schema.json
           json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           base_dir: mainnet
           json_schema: ./schemas/metadata.schema.json
-          json_exclude_regex: ^(?!metadata\.json$).*
+          json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -60,13 +60,11 @@ jobs:
       - name: Checking out ${{ matrix.file }}
         uses: actions/checkout@v3
         with:
-          path: metadata
           sparse-checkout: ${{ matrix.file }}
 
       - name: Output contents of ${{ matrix.file }}
         id: setmetadata
         run: |
-          cd metadata
           CONTENTS=$(cat ${{ matrix.file }} | jq .)
           SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
           if [ -z "$SOURCE" ]; then
@@ -76,11 +74,10 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          echo "metadata=${CONTENTS}" >> $GITHUB_OUTPUT
-          cd ..
+          echo "::set-output name=metadata::$CONTENTS"
       
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          repository: ${{ fromJSON(steps.setmetadata.outputs.metadata).source.repository }}
-          ref: ${{ fromJSON(steps.setmetadata.outputs.metadata).source.tag }}
+          repository: ${{ needs.setmetadata.outputs.metadata).source.repository }}
+          ref: ${{ needs.setmetadata.outputs.metadata).source.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -32,6 +32,7 @@ jobs:
         uses: tj-actions/changed-files@v39
 
       - name: Set metadata files
+        id: setfiles
         run: |
           FILES_ARRAY=()
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
@@ -43,7 +44,7 @@ jobs:
           done
           echo "metadata_files=${FILES_ARRAY[@]}" >> $GITHUB_OUTPUT
     outputs:
-      metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}
+      metadata_files: ${{ toJSON(steps.setfiles.outputs.metadata_files) }}
 
   validate-metadata:
     name: Validate the Source Builder 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -99,3 +99,9 @@ jobs:
       - name: Build the binary
         run: |
           docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}
+
+      - name: Fetch the contract checksum
+        run: |
+          CHECKSUMLINE=$(grep -n ${{ steps.setmetadata.outputs.source_builder_contract_name }} artifacts/checksums.txt )
+          CHECKSUM=$(echo $CHECKSUMLINE | cut -d ' ' -f 1)
+          echo $CHECKSUM

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -45,7 +45,7 @@ jobs:
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             FILES_ARRAY+=($file)
           done
-          echo "::set-output name=matrix::FILES_ARRAY"
+          echo "::set-output name=matrix::$FILES_ARRAY"
 
   validate-metadata:
     name: Validate the Source Builder 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Validate JSON
         uses: GrantBirki/json-yaml-validate@v2.3.1
         with:
-          base_dir: mainnet
           json_schema: ./schemas/metadata.schema.json
           json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false
@@ -28,11 +27,14 @@ jobs:
       pull-requests: read
 
     steps:
+      # Get all the files which have been changed in this PR
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v39
 
-      - name: Set metadata files
+      # Output all the files which were changed and match the path mainnet/*/metadata.json
+      # We only do this for mainnet as the optimization takes a long time. Not worth it for testnet imo
+      - name: Set changed metadata files
         id: setfiles
         run: |
           FILES_ARRAY=""
@@ -41,7 +43,12 @@ jobs:
             if [ $FILE_NAME != "metadata.json" ]; then
                 continue
             fi
-            FILES_ARRAY+="$file,"
+            NETWORK=$(echo $file | cut -d '/' -f 1)
+            if [[ "$NETWORK" == "mainnet" ]]; then
+              FILES_ARRAY+="$file,"
+            else
+              continue
+            fi
           done
           FILES_ARRAY=$(echo $FILES_ARRAY | jq -R -s -c 'split(",")[:-1]')
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
@@ -49,7 +56,7 @@ jobs:
       metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
 
   build-binary:
-    name: Build contract binary
+    name: Build binary
     needs: [fetch-modified-metadata]
     runs-on: ubuntu-latest
     strategy:
@@ -58,17 +65,21 @@ jobs:
         file: ${{ fromJSON(needs.fetch-modified-metadata.outputs.metadata_files) }}
 
     steps:
+      # Checkout just the path to the metadata file
       - name: Checking out ${{ matrix.file }}
         uses: actions/checkout@v3
         with:
           sparse-checkout: ${{ matrix.file }}
 
+      # Read the contents of the metadata file and output the contents as build variables
       - name: Output contents of ${{ matrix.file }}
         id: setmetadata
         run: |
           SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
           if [ -z "$SOURCE" ]; then
-              continue
+              echo "Source code details not provided. Skipping checksum verification."
+              exit 0
+              return
           fi
           SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository' | sed 's/https:\/\/github.com\///')
           SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
@@ -77,7 +88,9 @@ jobs:
 
           SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
           if [ -z "$SOURCE_BUILDER" ]; then
-              continue
+              echo "Source builder details not provided. Skipping checksum verification."
+              exit 0
+              return
           fi
           SOURCE_BUILDER_IMAGE=$(cat ${{ matrix.file }} | jq -r '.source_builder.image')
           SOURCE_BUILDER_TAG=$(cat ${{ matrix.file }} | jq -r '.source_builder.tag')
@@ -89,7 +102,7 @@ jobs:
           CODE_ID=$(cat ${{ matrix.file }} | jq -r '.code_id')
           echo "code_id=$CODE_ID" >> $GITHUB_OUTPUT
 
-      
+      # Checkout the source code provided in the metadata.json
       - name: Checkout source code
         id: checkoutcode
         uses: actions/checkout@v3
@@ -97,9 +110,11 @@ jobs:
           repository: ${{ steps.setmetadata.outputs.source_repo }}
           ref: ${{ steps.setmetadata.outputs.source_tag }}
 
+      # Setup docker to be able to run contract optimizer 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # Run rust/workspace optimizer and gets the checksum of the resulting binary based on the given filename
       - name: Build the binary and get checksum
         run: |
           docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}
@@ -107,18 +122,10 @@ jobs:
           CHECKSUM=$(echo $CHECKSUMLINE | cut -d ' ' -f 1)
           echo "source_contract_checksum=$CHECKSUM" >> $GITHUB_OUTPUT
 
+      # Fetches the code hash from the network and compares it to the generated checksum
       - name: Verify checksums
         run: |
-          NETWORK=$(echo "$string" | cut -d '/' -f 1)
-          REST_URL=""
-          if [[ "$NETWORK" == "mainnet" ]]; then
-            REST_URL=https://api.mainnet.archway.io/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
-          elif [[ "$NETWORK" == "testnet" ]]; then
-            REST_URL=https://api.constantine.archway.tech/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
-          else
-            echo "Invalid network path found"
-          fi
-
+          REST_URL=https://api.mainnet.archway.io/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
           HASH=$(curl -X GET $REST_URL -H  "accept: application/json" | jq -r '.code_info.data_hash' | tr '[:upper:]' '[:lower:]')
           GENERATED_HASH=${{ steps.setmetadata.outputs.source_contract_checksum }}
 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -20,8 +20,8 @@ jobs:
           json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false
 
-  fetch-modified-files:
-    name: Fetch modified files
+  fetch-modified-metadata:
+    name: Fetch modified metadata
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -31,8 +31,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
 
-      - name: Set outputs
-        id: setVariables
+      - name: Set metadata files
         run: |
           FILES_ARRAY=()
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
@@ -42,18 +41,20 @@ jobs:
             fi
             FILES_ARRAY+=($file)
           done
-          echo ${FILES_ARRAY[@]}
+          echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
+        output:
+          metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}
 
-  # validate-metadata:
-  #   name: Validate the Source Builder 
-  #   needs: [fetch-modified-files]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       file: ${{needs.fetch-modified-files.outputs.matrix}}
+  validate-metadata:
+    name: Validate the Source Builder 
+    needs: [fetch-modified-files]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        file: ${{ fromJSON(needs.fetch-modified-metadata.outputs.metadata_files) }}
 
-  #   steps:
-  #     - name: Output
-  #       run: | 
-  #         echo ${{ matrix.file }}
+    steps:
+      - name: Output
+        run: | 
+          echo ${{ matrix.file }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -1,4 +1,4 @@
-name: Metadata schema check
+name: Metadata Check
 
 on:
   push: 
@@ -7,12 +7,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  validate-json:
+  validate-json-schema:
+    name: Validate the Metadata JSON schema
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v3  
       - name: Validate JSON
         uses: GrantBirki/json-yaml-validate@v2.3.1
         with:
@@ -20,3 +20,15 @@ jobs:
           json_schema: ./schemas/metadata.schema.json
           json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false
+
+  validate-source-builder:
+    name: Validate the Source Builder 
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Publish the latest changes
+        run: |
+        CHANGED_FILES_PATH=$(git diff --name-only main)
+        echo $CHANGED_FILES_PATH

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -87,4 +87,4 @@ jobs:
 
       - name: Build the binary
         run: |
-        docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}
+          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -47,7 +47,7 @@ jobs:
 
   validate-metadata:
     name: Validate the Source Builder 
-    needs: [fetch-modified-files]
+    needs: [fetch-modified-metadata]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Get changed files using defaults
         id: changed-files

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -30,7 +30,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Publish the latest changes
+      - name: Get changed files using defaults
+        id: changed-files
+        uses: tj-actions/changed-files@v32
+
+      - name: List all added files
         run: |
-          CHANGED_FILES_PATH=$(git diff --name-only main)
-          echo $CHANGED_FILES_PATH
+          for file in ${{ steps.changed-files.outputs.modified_files }}; do
+              echo "$file was modified."
+          done

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -81,3 +81,10 @@ jobs:
         with:
           repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
           ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build the binary
+        run: |
+        docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -24,7 +24,7 @@ jobs:
     name: Validate the Source Builder 
     runs-on: ubuntu-latest
     permissions:
-    pull-requests: read
+      pull-requests: read
 
     steps:
       - name: Get changed files

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -20,11 +20,13 @@ jobs:
           json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false
 
-  validate-source-builder:
-    name: Validate the Source Builder 
+  fetch-modified-files:
+    name: Fetch modified files
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
+    outputs:
+      matrix: ${{ steps.setVariables.outputs.matrix }}
 
     steps:
       - name: Get changed files
@@ -36,3 +38,20 @@ jobs:
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "$file was changed"
           done
+      - name: Set outputs
+        id: setVariables
+        run: |
+          echo "::set-output name=matrix::${{ steps.changed-files.outputs.all_changed_files }}"
+
+  validate-metadata:
+    name: Validate the Source Builder 
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        file: ${{fromJson(needs.fetch-modified-files.outputs.matrix)}}
+
+    steps:
+      - name: Output
+        run: | 
+          echo ${{ matrix.file }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -116,7 +116,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       # Run rust/workspace optimizer and gets the checksum of the resulting binary based on the given filename
-      - name: Build the binary and get checksum
+      - name: Build the binary and get checksum 
+        id: setchecksum
         run: |
           docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}
           CHECKSUMLINE=$(grep -h ${{ steps.setmetadata.outputs.source_builder_contract_name }} artifacts/checksums.txt )
@@ -128,7 +129,7 @@ jobs:
         run: |
           REST_URL=https://api.mainnet.archway.io/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
           HASH=$(curl -X GET $REST_URL -H  "accept: application/json" | jq -r '.code_info.data_hash' | tr '[:upper:]' '[:lower:]')
-          GENERATED_HASH=${{ steps.setmetadata.outputs.source_contract_checksum }}
+          GENERATED_HASH=${{ steps.setchecksum.outputs.source_contract_checksum }}
 
           echo "hash=$HASH" 
           echo "generated=$GENERATED_HASH" 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -74,8 +74,7 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          #echo "metadata=$CONTENTS" >> $GITHUB_ENV
-          echo "count=5" >> $GITHUB_STATE
+          echo "count=5" >> $GITHUB_OUTPUT
 
       - name: Test
         run: |

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -65,37 +65,30 @@ jobs:
       - name: Output contents of ${{ matrix.file }}
         id: setmetadata
         run: |
-          CONTENTS=$(cat ${{ matrix.file }})
           SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
           if [ -z "$SOURCE" ]; then
               continue
           fi
           SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository')
           SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
+          echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
+          echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
+
           SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          echo "count=5" >> $GITHUB_OUTPUT
-          echo "count2=51" >> $GITHUB_OUTPUT
-          echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
-          echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Test
-        run: |
-          echo "The count was ${{ steps.setmetadata.outputs.source_repo }}"
-          echo "The count was ${{ steps.setmetadata.outputs.source_tag }}"
-        
       
       - name: Checkout source code
         id: checkoutcode
         uses: actions/checkout@v3
         with:
-          repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
-          ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
+          repository: ${{ steps.setmetadata.outputs.source_repo }}
+          ref: ${{ steps.setmetadata.outputs.source_tag }}
 
-      # - name: Setup Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       # - name: Build the binary
       #   run: |

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -23,18 +23,16 @@ jobs:
   validate-source-builder:
     name: Validate the Source Builder 
     runs-on: ubuntu-latest
+    permissions:
+    pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changed files using defaults
+      - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v39
 
-      - name: List all added files
+      - name: List all changed files
         run: |
-          for file in ${{ steps.changed-files.outputs.modified_files }}; do
-              echo "$file was modified."
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file was changed"
           done

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -45,7 +45,7 @@ jobs:
           FILES_ARRAY=$(echo $FILES_ARRAY | jq -R -s -c 'split(",")[:-1]')
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
     outputs:
-      metadata_files: ${{ toJSON(steps.setfiles.outputs.metadata_files) }}
+      metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
 
   validate-metadata:
     name: Validate the Source Builder 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-    outputs:
-      matrix: ${{ steps.setVariables.outputs.matrix }}
 
     steps:
       - name: Get changed files
@@ -38,7 +36,7 @@ jobs:
         run: |
           FILES_ARRAY=()
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            FILE_NAME=$(basename $FILE_PATH)
+            FILE_NAME=$(basename $file)
             if [ $FILE_NAME != "metadata.json" ]; then
                 continue
             fi

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Set outputs
         id: setVariables
         run: |
-          echo "::set-output name=matrix::${{ steps.changed-files.outputs.all_changed_files }}"
+          FILES_ARRAY=()
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            FILES_ARRAY+=($file)
+          done
+          echo "::set-output name=matrix::FILES_ARRAY"
 
   validate-metadata:
     name: Validate the Source Builder 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Output contents of ${{ matrix.file }}
         id: setmetadata
         run: |
-          CONTENTS=$(cat ${{ matrix.file }} | jq .)
+          CONTENTS=$(cat ${{ matrix.file }})
           SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
           if [ -z "$SOURCE" ]; then
               continue
@@ -79,12 +79,12 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          repository: ${{ fromJSON(needs.setmetadata.outputs.metadata.source.repository) }}
-          ref: ${{ fromJSON(needs.setmetadata.outputs.metadata.source.tag) }}
+          repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
+          ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build the binary
         run: |
-          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ fromJSON(needs.setmetadata.outputs.metadata.source_builder.image) }}:${{ fromJSON(needs.setmetadata.outputs.metadata.source_builder.tag) }}
+          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -57,6 +57,10 @@ jobs:
         file: ${{ fromJSON(needs.fetch-modified-metadata.outputs.metadata_files) }}
 
     steps:
-      - name: Output
-        run: | 
-          echo ${{ matrix.file }}
+      - name: Checking out ${{ matrix.file }}
+        uses: actions/checkout@v3
+        with:
+          path: ${{ matrix.file }}
+
+      - name: Output contents of ${{ matrix.file }}
+        run: cat ${{ matrix.file }} | jq .

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -47,8 +47,8 @@ jobs:
     outputs:
       metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
 
-  validate-metadata:
-    name: Validate the Source Builder 
+  load-metadata:
+    name: Load the code metadata
     needs: [fetch-modified-metadata]
     runs-on: ubuntu-latest
     strategy:
@@ -63,4 +63,22 @@ jobs:
           sparse-checkout: ${{ matrix.file }}
 
       - name: Output contents of ${{ matrix.file }}
-        run: cat ${{ matrix.file }} | jq .
+        id: setmetadata
+        run: |
+          CONTENTS=$(cat ${{ matrix.file }})
+          SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
+          if [ -z "$SOURCE_BUILDER" ]; then
+              continue
+          fi
+          echo "metadata=${CONTENTS}" >> $GITHUB_OUTPUT
+    outputs:
+      metadata: ${{ toJSON(steps.setmetadata.outputs.metadata) }}
+
+  build-binary:
+    name: Build contract binary
+    needs: [load-metadata]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Output metadata
+        run: echo ${{ fromJSON(needs.load-metadata.outputs.metadata) }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -1,10 +1,9 @@
 name: Metadata Check
 
 on:
-  push: 
   pull_request:
-
-  workflow_dispatch:
+    branches:
+      - main
 
 jobs:
   validate-json-schema:
@@ -26,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Get changed files using defaults
         id: changed-files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v39
 
       - name: List all added files
         run: |

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -75,14 +75,12 @@ jobs:
               continue
           fi
           #echo "metadata=$CONTENTS" >> $GITHUB_ENV
-          echo "::set-output name=variable1::value1"
-          echo "::set-output name=variable2::value2"
+          echo "variable1=value1" >> $GITHUB_STATE
 
       - name: Test
         run: |
-          echo ${{ steps.setvariables.outputs.variable1 }} 
+          echo ${{ steps.setmetadata.outputs.variable1 }} 
         
-          echo ${{ steps.setvariables.outputs.variable1 }}  
       
       # - name: Checkout source code
       #   id: checkoutcode

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -78,6 +78,12 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
+          SOURCE_BUILDER_IMAGE=$(cat ${{ matrix.file }} | jq -r '.source_builder.image')
+          SOURCE_BUILDER_TAG=$(cat ${{ matrix.file }} | jq -r '.source_builder.tag')
+          SOURCE_BUILDER_CONTRACT_NAME=$(cat ${{ matrix.file }} | jq -r '.source_builder.contract_name')
+          echo "source_builder_image=$SOURCE_BUILDER_IMAGE" >> $GITHUB_OUTPUT
+          echo "source_builder_tag=$SOURCE_BUILDER_TAG" >> $GITHUB_OUTPUT
+          echo "source_builder_contract_name=$SOURCE_BUILDER_CONTRACT_NAME" >> $GITHUB_OUTPUT
 
       
       - name: Checkout source code
@@ -90,6 +96,6 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: Build the binary
-      #   run: |
-      #     docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}
+      - name: Build the binary
+        run: |
+          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -74,7 +74,7 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          echo "::set-output name=metadata::$CONTENTS"
+          echo "metadata=$CONTENTS" >> $GITHUB_ENV
       
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -41,7 +41,7 @@ jobs:
             fi
             FILES_ARRAY+=($file)
           done
-          echo ${{ toJSON($FILES_ARRAY) }}
+          echo ${{ toJSON(${FILES_ARRAY}) }}
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
     outputs:
       metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checking out ${{ matrix.file }}
         uses: actions/checkout@v3
         with:
-          path: ${{ matrix.file }}
+          sparse-checkout: ${{ matrix.file }}
 
       - name: Output contents of ${{ matrix.file }}
         run: cat ${{ matrix.file }} | jq .

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -75,10 +75,12 @@ jobs:
               continue
           fi
           echo "count=5" >> $GITHUB_OUTPUT
+          echo "count2=51" >> $GITHUB_OUTPUT
 
       - name: Test
         run: |
           echo "The count was ${{ steps.setmetadata.outputs.count }}"
+          echo "The count was ${{ steps.setmetadata.outputs.count2 }}"
         
       
       # - name: Checkout source code

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
 
       - name: Publish the latest changes
         run: |

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -79,5 +79,5 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          repository: ${{ needs.setmetadata.outputs.metadata).source.repository }}
-          ref: ${{ needs.setmetadata.outputs.metadata).source.tag }}
+          repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
+          ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -47,8 +47,8 @@ jobs:
     outputs:
       metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
 
-  load-metadata:
-    name: Load the code metadata
+  build-binary:
+    name: Build contract binary
     needs: [fetch-modified-metadata]
     runs-on: ubuntu-latest
     strategy:
@@ -60,25 +60,27 @@ jobs:
       - name: Checking out ${{ matrix.file }}
         uses: actions/checkout@v3
         with:
+          path: metadata
           sparse-checkout: ${{ matrix.file }}
 
       - name: Output contents of ${{ matrix.file }}
         id: setmetadata
         run: |
+          cd metadata
           CONTENTS=$(cat ${{ matrix.file }})
+          SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
+          if [ -z "$SOURCE" ]; then
+              continue
+          fi
           SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
           echo "metadata=${CONTENTS}" >> $GITHUB_OUTPUT
-    outputs:
-      metadata: ${{ toJSON(steps.setmetadata.outputs.metadata) }}
-
-  build-binary:
-    name: Build contract binary
-    needs: [load-metadata]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Output metadata
-        run: echo ${{ fromJSON(needs.load-metadata.outputs.metadata) }}
+          cd ..
+      
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ fromJSON(steps.setmetadata.outputs.metadata).source.repository }}
+          ref: ${{ fromJSON(steps.setmetadata.outputs.metadata).source.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -70,25 +70,29 @@ jobs:
           if [ -z "$SOURCE" ]; then
               continue
           fi
+          SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository')
+          SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
           SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
           echo "count=5" >> $GITHUB_OUTPUT
           echo "count2=51" >> $GITHUB_OUTPUT
+          echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
+          echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
 
       - name: Test
         run: |
-          echo "The count was ${{ steps.setmetadata.outputs.count }}"
-          echo "The count was ${{ steps.setmetadata.outputs.count2 }}"
+          echo "The count was ${{ steps.setmetadata.outputs.source_repo }}"
+          echo "The count was ${{ steps.setmetadata.outputs.source_tag }}"
         
       
-      # - name: Checkout source code
-      #   id: checkoutcode
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
-      #     ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
+      - name: Checkout source code
+        id: checkoutcode
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
+          ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
 
       # - name: Setup Docker Buildx
       #   uses: docker/setup-buildx-action@v2

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -69,8 +69,8 @@ jobs:
           if [ -z "$SOURCE" ]; then
               continue
           fi
-          SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository' | sed 's/https:\/\/github.com\///' | cut -d '/' -f 1)
-          SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag' | sed 's/https:\/\/github.com\///' | cut -d '/' -f 2)
+          SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository' | sed 's/https:\/\/github.com\///')
+          SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
           echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
           echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -40,7 +40,7 @@ jobs:
             if [ $FILE_NAME != "metadata.json" ]; then
                 continue
             fi
-            FILES_ARRAY+="$file,"
+            FILES_ARRAY+="$(printf "%q " $file),"
           done
           FILES_ARRAY="${FILES_ARRAY%,}"
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -74,17 +74,17 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          echo "metadata=$CONTENTS" >> $GITHUB_ENV
+          echo "::set-env name=METADATA::$CONTENTS"
       
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
-          ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
+          repository: $METADATA.source.repository
+          ref: $METADATA.source.tag
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build the binary
         run: |
-          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}
+          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry  $METADATA.source_builder.image:$METADATA.source_builder.tag

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -41,8 +41,7 @@ jobs:
             fi
             FILES_ARRAY+=($file)
           done
-          echo ${{ toJSON(${FILES_ARRAY}) }}
-          echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
+          echo "metadata_files=${FILES_ARRAY[@]}" >> $GITHUB_OUTPUT
     outputs:
       metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}
 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -74,17 +74,17 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          echo "::set-env name=METADATA::$CONTENTS"
+          echo "metadata=$CONTENTS" >> $GITHUB_ENV
       
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          repository: $METADATA.source.repository
-          ref: $METADATA.source.tag
+          repository: ${{ fromJSON(needs.setmetadata.outputs.metadata.source.repository) }}
+          ref: ${{ fromJSON(needs.setmetadata.outputs.metadata.source.tag) }}
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build the binary
         run: |
-          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry  $METADATA.source_builder.image:$METADATA.source_builder.tag
+          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ fromJSON(needs.setmetadata.outputs.metadata.source_builder.image) }}:${{ fromJSON(needs.setmetadata.outputs.metadata.source_builder.tag) }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -40,8 +40,9 @@ jobs:
             if [ $FILE_NAME != "metadata.json" ]; then
                 continue
             fi
-            FILES_ARRAY+="($file),"
+            FILES_ARRAY+="$file,"
           done
+          FILES_ARRAY="${FILES_ARRAY%,}"
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
     outputs:
       metadata_files: ${{ toJSON(steps.setfiles.outputs.metadata_files) }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -67,7 +67,7 @@ jobs:
         id: setmetadata
         run: |
           cd metadata
-          CONTENTS=$(cat ${{ matrix.file }})
+          CONTENTS=$(cat ${{ matrix.file }} | jq .)
           SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
           if [ -z "$SOURCE" ]; then
               continue

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -74,17 +74,26 @@ jobs:
           if [ -z "$SOURCE_BUILDER" ]; then
               continue
           fi
-          echo "metadata=$CONTENTS" >> $GITHUB_ENV
-      
-      - name: Checkout source code
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
-          ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
+          #echo "metadata=$CONTENTS" >> $GITHUB_ENV
+          echo "::set-output name=variable1::value1"
+          echo "::set-output name=variable2::value2"
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build the binary
+      - name: Test
         run: |
-          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}
+          echo ${{ steps.setvariables.outputs.variable1 }} 
+        
+          echo ${{ steps.setvariables.outputs.variable1 }}  
+      
+      # - name: Checkout source code
+      #   id: checkoutcode
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: ${{ needs.setmetadata.outputs.metadata.source.repository }}
+      #     ref: ${{ needs.setmetadata.outputs.metadata.source.tag }}
+
+      # - name: Setup Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+
+      # - name: Build the binary
+      #   run: |
+      #     docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ needs.setmetadata.outputs.metadata.source_builder.image }}:${{ needs.setmetadata.outputs.metadata.source_builder.tag }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -40,9 +40,9 @@ jobs:
             if [ $FILE_NAME != "metadata.json" ]; then
                 continue
             fi
-            FILES_ARRAY+="$(printf "%q " $file),"
+            FILES_ARRAY+="$file,"
           done
-          FILES_ARRAY="${FILES_ARRAY%,}"
+          FILES_ARRAY=$(echo $FILES_ARRAY | jq -R -s -c 'split(",")[:-1]')
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
     outputs:
       metadata_files: ${{ toJSON(steps.setfiles.outputs.metadata_files) }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -69,8 +69,8 @@ jobs:
           if [ -z "$SOURCE" ]; then
               continue
           fi
-          SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository')
-          SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
+          SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository' | sed 's/https:\/\/github.com\///' | cut -d '/' -f 1)
+          SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag' | sed 's/https:\/\/github.com\///' | cut -d '/' -f 2)
           echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
           echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -42,7 +42,7 @@ jobs:
             FILES_ARRAY+=($file)
           done
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
-        output:
+        outputs:
           metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}
 
   validate-metadata:

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -20,123 +20,125 @@ jobs:
           json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
           use_gitignore: false
 
-  fetch-modified-metadata:
-    name: Fetch modified metadata
-    needs: [validate-json-schema]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
+  ## Currently not running these as these are very time intensive 
 
-    steps:
-      # Get all the files which have been changed in this PR
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v39
+  # fetch-modified-metadata:
+  #   name: Fetch modified metadata
+  #   needs: [validate-json-schema]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     pull-requests: read
 
-      # Output all the files which were changed and match the path mainnet/*/metadata.json
-      # We only do this for mainnet as the optimization takes a long time. Not worth it for testnet imo
-      - name: Set changed metadata files
-        id: setfiles
-        run: |
-          FILES_ARRAY=""
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            FILE_NAME=$(basename $file)
-            if [ $FILE_NAME != "metadata.json" ]; then
-                continue
-            fi
-            NETWORK=$(echo $file | cut -d '/' -f 1)
-            if [[ "$NETWORK" == "mainnet" ]]; then
-              FILES_ARRAY+="$file,"
-            else
-              continue
-            fi
-          done
-          FILES_ARRAY=$(echo $FILES_ARRAY | jq -R -s -c 'split(",")[:-1]')
-          echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
-    outputs:
-      metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
+  #   steps:
+  #     # Get all the files which have been changed in this PR
+  #     - name: Get changed files
+  #       id: changed-files
+  #       uses: tj-actions/changed-files@v39
 
-  build-binary:
-    name: Build binary
-    needs: [fetch-modified-metadata]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        file: ${{ fromJSON(needs.fetch-modified-metadata.outputs.metadata_files) }}
+  #     # Output all the files which were changed and match the path mainnet/*/metadata.json
+  #     # We only do this for mainnet as the optimization takes a long time. Not worth it for testnet imo
+  #     - name: Set changed metadata files
+  #       id: setfiles
+  #       run: |
+  #         FILES_ARRAY=""
+  #         for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+  #           FILE_NAME=$(basename $file)
+  #           if [ $FILE_NAME != "metadata.json" ]; then
+  #               continue
+  #           fi
+  #           NETWORK=$(echo $file | cut -d '/' -f 1)
+  #           if [[ "$NETWORK" == "mainnet" ]]; then
+  #             FILES_ARRAY+="$file,"
+  #           else
+  #             continue
+  #           fi
+  #         done
+  #         FILES_ARRAY=$(echo $FILES_ARRAY | jq -R -s -c 'split(",")[:-1]')
+  #         echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
+  #   outputs:
+  #     metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
 
-    steps:
-      # Checkout just the path to the metadata file
-      - name: Checking out ${{ matrix.file }}
-        uses: actions/checkout@v3
-        with:
-          sparse-checkout: ${{ matrix.file }}
+  # build-binary:
+  #   name: Build binary
+  #   needs: [fetch-modified-metadata]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       file: ${{ fromJSON(needs.fetch-modified-metadata.outputs.metadata_files) }}
 
-      # Read the contents of the metadata file and output the contents as build variables
-      - name: Output contents of ${{ matrix.file }}
-        id: setmetadata
-        run: |
-          SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
-          if [ -z "$SOURCE" ]; then
-              echo "Source code details not provided. Skipping checksum verification."
-              exit 0
-              return
-          fi
-          SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository' | sed 's/https:\/\/github.com\///')
-          SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
-          echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
-          echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
+  #   steps:
+  #     # Checkout just the path to the metadata file
+  #     - name: Checking out ${{ matrix.file }}
+  #       uses: actions/checkout@v3
+  #       with:
+  #         sparse-checkout: ${{ matrix.file }}
 
-          SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
-          if [ -z "$SOURCE_BUILDER" ]; then
-              echo "Source builder details not provided. Skipping checksum verification."
-              exit 0
-              return
-          fi
-          SOURCE_BUILDER_IMAGE=$(cat ${{ matrix.file }} | jq -r '.source_builder.image')
-          SOURCE_BUILDER_TAG=$(cat ${{ matrix.file }} | jq -r '.source_builder.tag')
-          SOURCE_BUILDER_CONTRACT_NAME=$(cat ${{ matrix.file }} | jq -r '.source_builder.contract_name')
-          echo "source_builder_image=$SOURCE_BUILDER_IMAGE" >> $GITHUB_OUTPUT
-          echo "source_builder_tag=$SOURCE_BUILDER_TAG" >> $GITHUB_OUTPUT
-          echo "source_builder_contract_name=$SOURCE_BUILDER_CONTRACT_NAME" >> $GITHUB_OUTPUT
+  #     # Read the contents of the metadata file and output the contents as build variables
+  #     - name: Output contents of ${{ matrix.file }}
+  #       id: setmetadata
+  #       run: |
+  #         SOURCE=$(cat ${{ matrix.file }} | jq -r '.source')
+  #         if [ -z "$SOURCE" ]; then
+  #             echo "Source code details not provided. Skipping checksum verification."
+  #             exit 0
+  #             return
+  #         fi
+  #         SOURCE_REPO=$(cat ${{ matrix.file }} | jq -r '.source.repository' | sed 's/https:\/\/github.com\///')
+  #         SOURCE_TAG=$(cat ${{ matrix.file }} | jq -r '.source.tag')
+  #         echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
+  #         echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
 
-          CODE_ID=$(cat ${{ matrix.file }} | jq -r '.code_id')
-          echo "code_id=$CODE_ID" >> $GITHUB_OUTPUT
+  #         SOURCE_BUILDER=$(cat ${{ matrix.file }} | jq -r '.source_builder')
+  #         if [ -z "$SOURCE_BUILDER" ]; then
+  #             echo "Source builder details not provided. Skipping checksum verification."
+  #             exit 0
+  #             return
+  #         fi
+  #         SOURCE_BUILDER_IMAGE=$(cat ${{ matrix.file }} | jq -r '.source_builder.image')
+  #         SOURCE_BUILDER_TAG=$(cat ${{ matrix.file }} | jq -r '.source_builder.tag')
+  #         SOURCE_BUILDER_CONTRACT_NAME=$(cat ${{ matrix.file }} | jq -r '.source_builder.contract_name')
+  #         echo "source_builder_image=$SOURCE_BUILDER_IMAGE" >> $GITHUB_OUTPUT
+  #         echo "source_builder_tag=$SOURCE_BUILDER_TAG" >> $GITHUB_OUTPUT
+  #         echo "source_builder_contract_name=$SOURCE_BUILDER_CONTRACT_NAME" >> $GITHUB_OUTPUT
 
-      # Checkout the source code provided in the metadata.json
-      - name: Checkout source code
-        id: checkoutcode
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ steps.setmetadata.outputs.source_repo }}
-          ref: ${{ steps.setmetadata.outputs.source_tag }}
+  #         CODE_ID=$(cat ${{ matrix.file }} | jq -r '.code_id')
+  #         echo "code_id=$CODE_ID" >> $GITHUB_OUTPUT
 
-      # Setup docker to be able to run contract optimizer 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+  #     # Checkout the source code provided in the metadata.json
+  #     - name: Checkout source code
+  #       id: checkoutcode
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: ${{ steps.setmetadata.outputs.source_repo }}
+  #         ref: ${{ steps.setmetadata.outputs.source_tag }}
 
-      # Run rust/workspace optimizer and gets the checksum of the resulting binary based on the given filename
-      - name: Build the binary and get checksum 
-        id: setchecksum
-        run: |
-          docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}
-          CHECKSUMLINE=$(grep -h ${{ steps.setmetadata.outputs.source_builder_contract_name }} artifacts/checksums.txt )
-          CHECKSUM=$(echo $CHECKSUMLINE | cut -d ' ' -f 1)
-          echo "source_contract_checksum=$CHECKSUM" >> $GITHUB_OUTPUT
+  #     # Setup docker to be able to run contract optimizer 
+  #     - name: Setup Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
 
-      # Fetches the code hash from the network and compares it to the generated checksum
-      - name: Verify checksums
-        run: |
-          REST_URL=https://api.mainnet.archway.io/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
-          HASH=$(curl -X GET $REST_URL -H  "accept: application/json" | jq -r '.code_info.data_hash' | tr '[:upper:]' '[:lower:]')
-          GENERATED_HASH=${{ steps.setchecksum.outputs.source_contract_checksum }}
+  #     # Run rust/workspace optimizer and gets the checksum of the resulting binary based on the given filename
+  #     - name: Build the binary and get checksum 
+  #       id: setchecksum
+  #       run: |
+  #         docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}
+  #         CHECKSUMLINE=$(grep -h ${{ steps.setmetadata.outputs.source_builder_contract_name }} artifacts/checksums.txt )
+  #         CHECKSUM=$(echo $CHECKSUMLINE | cut -d ' ' -f 1)
+  #         echo "source_contract_checksum=$CHECKSUM" >> $GITHUB_OUTPUT
 
-          echo "hash=$HASH" 
-          echo "generated=$GENERATED_HASH" 
+  #     # Fetches the code hash from the network and compares it to the generated checksum
+  #     - name: Verify checksums
+  #       run: |
+  #         REST_URL=https://api.mainnet.archway.io/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
+  #         HASH=$(curl -X GET $REST_URL -H  "accept: application/json" | jq -r '.code_info.data_hash' | tr '[:upper:]' '[:lower:]')
+  #         GENERATED_HASH=${{ steps.setchecksum.outputs.source_contract_checksum }}
 
-          if [[ "$HASH" == "$GENERATED_HASH" ]]; then
-            echo "The strings are the same"
-          else
-            echo "The hashes do not match"
-            exit 1
-          fi
+  #         echo "hash=$HASH" 
+  #         echo "generated=$GENERATED_HASH" 
+
+  #         if [[ "$HASH" == "$GENERATED_HASH" ]]; then
+  #           echo "The strings are the same"
+  #         else
+  #           echo "The hashes do not match"
+  #           exit 1
+  #         fi

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -42,8 +42,8 @@ jobs:
             FILES_ARRAY+=($file)
           done
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
-        outputs:
-          metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}
+    outputs:
+      metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}
 
   validate-metadata:
     name: Validate the Source Builder 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -19,3 +19,4 @@ jobs:
           base_dir: mainnet
           json_schema: ./schemas/metadata.schema.json
           json_exclude_regex: ^(?!metadata\.json$).*
+          use_gitignore: false

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -75,11 +75,11 @@ jobs:
               continue
           fi
           #echo "metadata=$CONTENTS" >> $GITHUB_ENV
-          echo "variable1=value1" >> $GITHUB_STATE
+          echo "count=5" >> $GITHUB_STATE
 
       - name: Test
         run: |
-          echo ${{ steps.setmetadata.outputs.variable1 }} 
+          echo "The count was ${{ steps.setmetadata.outputs.count }}"
         
       
       # - name: Checkout source code

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -33,11 +33,11 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
 
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file was changed"
-          done
+      # - name: List all changed files
+      #   run: |
+      #     for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+      #       echo "$file was changed"
+      #     done
       - name: Set outputs
         id: setVariables
         run: |
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        file: ${{fromJson(needs.fetch-modified-files.outputs.matrix)}}
+        file: ${{needs.fetch-modified-files.outputs.matrix}}
 
     steps:
       - name: Output

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -41,6 +41,7 @@ jobs:
             fi
             FILES_ARRAY+=($file)
           done
+          echo ${{ toJSON($FILES_ARRAY) }}
           echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
     outputs:
       metadata_files: ${{ toJSON(steps.*.outputs.metadata_files) }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -34,15 +34,15 @@ jobs:
       - name: Set metadata files
         id: setfiles
         run: |
-          FILES_ARRAY=()
+          FILES_ARRAY=""
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             FILE_NAME=$(basename $file)
             if [ $FILE_NAME != "metadata.json" ]; then
                 continue
             fi
-            FILES_ARRAY+=($file)
+            FILES_ARRAY+="($file),"
           done
-          echo "metadata_files=${FILES_ARRAY[@]}" >> $GITHUB_OUTPUT
+          echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
     outputs:
       metadata_files: ${{ toJSON(steps.setfiles.outputs.metadata_files) }}
 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -1,0 +1,21 @@
+name: Metadata schema check
+
+on:
+  push: 
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  validate-json:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Validate JSON
+        uses: GrantBirki/json-yaml-validate@v2.3.1
+        with:
+          base_dir: mainnet
+          json_schema: ./schemas/metadata.schema.json
+          json_exclude_regex: ^(?!metadata\.json$).*

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -33,30 +33,29 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
 
-      # - name: List all changed files
-      #   run: |
-      #     for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-      #       echo "$file was changed"
-      #     done
       - name: Set outputs
         id: setVariables
         run: |
           FILES_ARRAY=()
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            FILE_NAME=$(basename $FILE_PATH)
+            if [ $FILE_NAME != "metadata.json" ]; then
+                continue
+            fi
             FILES_ARRAY+=($file)
           done
-          echo "::set-output name=matrix::$FILES_ARRAY"
+          echo ${FILES_ARRAY[@]}
 
-  validate-metadata:
-    name: Validate the Source Builder 
-    needs: [fetch-modified-files]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        file: ${{needs.fetch-modified-files.outputs.matrix}}
+  # validate-metadata:
+  #   name: Validate the Source Builder 
+  #   needs: [fetch-modified-files]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       file: ${{needs.fetch-modified-files.outputs.matrix}}
 
-    steps:
-      - name: Output
-        run: | 
-          echo ${{ matrix.file }}
+  #   steps:
+  #     - name: Output
+  #       run: | 
+  #         echo ${{ matrix.file }}

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -22,6 +22,7 @@ jobs:
 
   fetch-modified-metadata:
     name: Fetch modified metadata
+    needs: [validate-json-schema]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -85,6 +86,9 @@ jobs:
           echo "source_builder_tag=$SOURCE_BUILDER_TAG" >> $GITHUB_OUTPUT
           echo "source_builder_contract_name=$SOURCE_BUILDER_CONTRACT_NAME" >> $GITHUB_OUTPUT
 
+          CODE_ID=$(cat ${{ matrix.file }} | jq -r '.code_id')
+          echo "code_id=$CODE_ID" >> $GITHUB_OUTPUT
+
       
       - name: Checkout source code
         id: checkoutcode
@@ -96,12 +100,34 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build the binary
+      - name: Build the binary and get checksum
         run: |
           docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   ${{ steps.setmetadata.outputs.source_builder_image }}:${{ steps.setmetadata.outputs.source_builder_tag }}
-
-      - name: Fetch the contract checksum
-        run: |
-          CHECKSUMLINE=$(grep -n ${{ steps.setmetadata.outputs.source_builder_contract_name }} artifacts/checksums.txt )
+          CHECKSUMLINE=$(grep -h ${{ steps.setmetadata.outputs.source_builder_contract_name }} artifacts/checksums.txt )
           CHECKSUM=$(echo $CHECKSUMLINE | cut -d ' ' -f 1)
-          echo $CHECKSUM
+          echo "source_contract_checksum=$CHECKSUM" >> $GITHUB_OUTPUT
+
+      - name: Verify checksums
+        run: |
+          NETWORK=$(echo "$string" | cut -d '/' -f 1)
+          REST_URL=""
+          if [[ "$NETWORK" == "mainnet" ]]; then
+            REST_URL=https://api.mainnet.archway.io/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
+          elif [[ "$NETWORK" == "testnet" ]]; then
+            REST_URL=https://api.constantine.archway.tech/cosmwasm/wasm/v1/code/${{ steps.setmetadata.outputs.code_id }}
+          else
+            echo "Invalid network path found"
+          fi
+
+          HASH=$(curl -X GET $REST_URL -H  "accept: application/json" | jq -r '.code_info.data_hash' | tr '[:upper:]' '[:lower:]')
+          GENERATED_HASH=${{ steps.setmetadata.outputs.source_contract_checksum }}
+
+          echo "hash=$HASH" 
+          echo "generated=$GENERATED_HASH" 
+
+          if [[ "$HASH" == "$GENERATED_HASH" ]]; then
+            echo "The strings are the same"
+          else
+            echo "The hashes do not match"
+            exit 1
+          fi

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -45,6 +45,7 @@ jobs:
 
   validate-metadata:
     name: Validate the Source Builder 
+    needs: [fetch-modified-files]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -27,8 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Publish the latest changes
         run: |
-        CHANGED_FILES_PATH=$(git diff --name-only main)
-        echo $CHANGED_FILES_PATH
+          CHANGED_FILES_PATH=$(git diff --name-only main)
+          echo $CHANGED_FILES_PATH

--- a/mainnet/4/metadata.json
+++ b/mainnet/4/metadata.json
@@ -1,0 +1,15 @@
+{
+    "code_id": 4,
+    "source": {
+        "repository": "https://github.com/DA0-DA0/dao-contracts",
+        "tag": "v2.1.0",
+        "license": "BSD 3-Clause"
+    },
+    "source_builder": {
+        "image": "cosmwasm/workspace-optimizer",
+        "tag": "0.12.11",
+        "contract_name": "dao_proposal_single.wasm"
+    },
+    "schema": "schema.json",
+    "contacts": []
+}

--- a/mainnet/4/schema.json
+++ b/mainnet/4/schema.json
@@ -1,0 +1,5921 @@
+{
+  "contract_name": "dao-proposal-single",
+  "contract_version": "2.0.3",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "allow_revoting",
+      "close_proposal_on_execution_failure",
+      "max_voting_period",
+      "only_members_execute",
+      "pre_propose_info",
+      "threshold"
+    ],
+    "properties": {
+      "allow_revoting": {
+        "description": "Allows changing votes before the proposal expires. If this is enabled proposals will not be able to complete early as final vote information is not known until the time of proposal expiration.",
+        "type": "boolean"
+      },
+      "close_proposal_on_execution_failure": {
+        "description": "If set to true proposals will be closed if their execution fails. Otherwise, proposals will remain open after execution failure. For example, with this enabled a proposal to send 5 tokens out of a DAO's treasury with 4 tokens would be closed when it is executed. With this disabled, that same proposal would remain open until the DAO's treasury was large enough for it to be executed.",
+        "type": "boolean"
+      },
+      "max_voting_period": {
+        "description": "The default maximum amount of time a proposal may be voted on before expiring.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Duration"
+          }
+        ]
+      },
+      "min_voting_period": {
+        "description": "The minimum amount of time a proposal must be open before passing. A proposal may fail before this amount of time has elapsed, but it will not pass. This can be useful for preventing governance attacks wherein an attacker aquires a large number of tokens and forces a proposal through.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/Duration"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "only_members_execute": {
+        "description": "If set to true only members may execute passed proposals. Otherwise, any address may execute a passed proposal.",
+        "type": "boolean"
+      },
+      "pre_propose_info": {
+        "description": "Information about what addresses may create proposals.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PreProposeInfo"
+          }
+        ]
+      },
+      "threshold": {
+        "description": "The threshold a proposal must reach to complete.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Threshold"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Admin": {
+        "description": "Information about the CosmWasm level admin of a contract. Used in conjunction with `ModuleInstantiateInfo` to instantiate modules.",
+        "oneOf": [
+          {
+            "description": "Set the admin to a specified address.",
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "object",
+                "required": [
+                  "addr"
+                ],
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Sets the admin as the core module address.",
+            "type": "object",
+            "required": [
+              "core_module"
+            ],
+            "properties": {
+              "core_module": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "Duration": {
+        "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Time in seconds",
+            "type": "object",
+            "required": [
+              "time"
+            ],
+            "properties": {
+              "time": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ModuleInstantiateInfo": {
+        "description": "Information needed to instantiate a module.",
+        "type": "object",
+        "required": [
+          "code_id",
+          "label",
+          "msg"
+        ],
+        "properties": {
+          "admin": {
+            "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Admin"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "code_id": {
+            "description": "Code ID of the contract to be instantiated.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "label": {
+            "description": "Label for the instantiated contract.",
+            "type": "string"
+          },
+          "msg": {
+            "description": "Instantiate message to be used to create the contract.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PercentageThreshold": {
+        "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
+        "oneOf": [
+          {
+            "description": "The majority of voters must vote yes for the proposal to pass.",
+            "type": "object",
+            "required": [
+              "majority"
+            ],
+            "properties": {
+              "majority": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
+            "type": "object",
+            "required": [
+              "percent"
+            ],
+            "properties": {
+              "percent": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PreProposeInfo": {
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal free of charge.",
+            "type": "object",
+            "required": [
+              "anyone_may_propose"
+            ],
+            "properties": {
+              "anyone_may_propose": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "The module specified in INFO has exclusive rights to proposal creation.",
+            "type": "object",
+            "required": [
+              "module_may_propose"
+            ],
+            "properties": {
+              "module_may_propose": {
+                "type": "object",
+                "required": [
+                  "info"
+                ],
+                "properties": {
+                  "info": {
+                    "$ref": "#/definitions/ModuleInstantiateInfo"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Threshold": {
+        "description": "The ways a proposal may reach its passing / failing threshold.",
+        "oneOf": [
+          {
+            "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
+            "type": "object",
+            "required": [
+              "absolute_percentage"
+            ],
+            "properties": {
+              "absolute_percentage": {
+                "type": "object",
+                "required": [
+                  "percentage"
+                ],
+                "properties": {
+                  "percentage": {
+                    "$ref": "#/definitions/PercentageThreshold"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
+            "type": "object",
+            "required": [
+              "threshold_quorum"
+            ],
+            "properties": {
+              "threshold_quorum": {
+                "type": "object",
+                "required": [
+                  "quorum",
+                  "threshold"
+                ],
+                "properties": {
+                  "quorum": {
+                    "$ref": "#/definitions/PercentageThreshold"
+                  },
+                  "threshold": {
+                    "$ref": "#/definitions/PercentageThreshold"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+            "type": "object",
+            "required": [
+              "absolute_count"
+            ],
+            "properties": {
+              "absolute_count": {
+                "type": "object",
+                "required": [
+                  "threshold"
+                ],
+                "properties": {
+                  "threshold": {
+                    "$ref": "#/definitions/Uint128"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "description": "Creates a proposal in the module.",
+        "type": "object",
+        "required": [
+          "propose"
+        ],
+        "properties": {
+          "propose": {
+            "$ref": "#/definitions/SingleChoiceProposeMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Votes on a proposal. Voting power is determined by the DAO's voting power module.",
+        "type": "object",
+        "required": [
+          "vote"
+        ],
+        "properties": {
+          "vote": {
+            "type": "object",
+            "required": [
+              "proposal_id",
+              "vote"
+            ],
+            "properties": {
+              "proposal_id": {
+                "description": "The ID of the proposal to vote on.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "rationale": {
+                "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "vote": {
+                "description": "The senders position on the proposal.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Vote"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Updates the sender's rationale for their vote on the specified proposal. Errors if no vote vote has been cast.",
+        "type": "object",
+        "required": [
+          "update_rationale"
+        ],
+        "properties": {
+          "update_rationale": {
+            "type": "object",
+            "required": [
+              "proposal_id"
+            ],
+            "properties": {
+              "proposal_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "rationale": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Causes the messages associated with a passed proposal to be executed by the DAO.",
+        "type": "object",
+        "required": [
+          "execute"
+        ],
+        "properties": {
+          "execute": {
+            "type": "object",
+            "required": [
+              "proposal_id"
+            ],
+            "properties": {
+              "proposal_id": {
+                "description": "The ID of the proposal to execute.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Closes a proposal that has failed (either not passed or timed out). If applicable this will cause the proposal deposit associated wth said proposal to be returned.",
+        "type": "object",
+        "required": [
+          "close"
+        ],
+        "properties": {
+          "close": {
+            "type": "object",
+            "required": [
+              "proposal_id"
+            ],
+            "properties": {
+              "proposal_id": {
+                "description": "The ID of the proposal to close.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Updates the governance module's config.",
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "allow_revoting",
+              "close_proposal_on_execution_failure",
+              "dao",
+              "max_voting_period",
+              "only_members_execute",
+              "threshold"
+            ],
+            "properties": {
+              "allow_revoting": {
+                "description": "Allows changing votes before the proposal expires. If this is enabled proposals will not be able to complete early as final vote information is not known until the time of proposal expiration.",
+                "type": "boolean"
+              },
+              "close_proposal_on_execution_failure": {
+                "description": "If set to true proposals will be closed if their execution fails. Otherwise, proposals will remain open after execution failure. For example, with this enabled a proposal to send 5 tokens out of a DAO's treasury with 4 tokens would be closed when it is executed. With this disabled, that same proposal would remain open until the DAO's treasury was large enough for it to be executed.",
+                "type": "boolean"
+              },
+              "dao": {
+                "description": "The address if tge DAO that this governance module is associated with.",
+                "type": "string"
+              },
+              "max_voting_period": {
+                "description": "The default maximum amount of time a proposal may be voted on before expiring. This will only apply to proposals created after the config update.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Duration"
+                  }
+                ]
+              },
+              "min_voting_period": {
+                "description": "The minimum amount of time a proposal must be open before passing. A proposal may fail before this amount of time has elapsed, but it will not pass. This can be useful for preventing governance attacks wherein an attacker aquires a large number of tokens and forces a proposal through.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Duration"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "only_members_execute": {
+                "description": "If set to true only members may execute passed proposals. Otherwise, any address may execute a passed proposal. Applies to all outstanding and future proposals.",
+                "type": "boolean"
+              },
+              "threshold": {
+                "description": "The new proposal passing threshold. This will only apply to proposals created after the config update.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Threshold"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update's the proposal creation policy used for this module. Only the DAO may call this method.",
+        "type": "object",
+        "required": [
+          "update_pre_propose_info"
+        ],
+        "properties": {
+          "update_pre_propose_info": {
+            "type": "object",
+            "required": [
+              "info"
+            ],
+            "properties": {
+              "info": {
+                "$ref": "#/definitions/PreProposeInfo"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Adds an address as a consumer of proposal hooks. Consumers of proposal hooks have hook messages executed on them whenever the status of a proposal changes or a proposal is created. If a consumer contract errors when handling a hook message it will be removed from the list of consumers.",
+        "type": "object",
+        "required": [
+          "add_proposal_hook"
+        ],
+        "properties": {
+          "add_proposal_hook": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes a consumer of proposal hooks.",
+        "type": "object",
+        "required": [
+          "remove_proposal_hook"
+        ],
+        "properties": {
+          "remove_proposal_hook": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Adds an address as a consumer of vote hooks. Consumers of vote hooks have hook messages executed on them whenever the a vote is cast. If a consumer contract errors when handling a hook message it will be removed from the list of consumers.",
+        "type": "object",
+        "required": [
+          "add_vote_hook"
+        ],
+        "properties": {
+          "add_vote_hook": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removed a consumer of vote hooks.",
+        "type": "object",
+        "required": [
+          "remove_vote_hook"
+        ],
+        "properties": {
+          "remove_vote_hook": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Admin": {
+        "description": "Information about the CosmWasm level admin of a contract. Used in conjunction with `ModuleInstantiateInfo` to instantiate modules.",
+        "oneOf": [
+          {
+            "description": "Set the admin to a specified address.",
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "object",
+                "required": [
+                  "addr"
+                ],
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Sets the admin as the core module address.",
+            "type": "object",
+            "required": [
+              "core_module"
+            ],
+            "properties": {
+              "core_module": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "BankMsg": {
+        "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
+        "oneOf": [
+          {
+            "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "send"
+            ],
+            "properties": {
+              "send": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
+                "properties": {
+                  "amount": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "to_address": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
+            "type": "object",
+            "required": [
+              "burn"
+            ],
+            "properties": {
+              "burn": {
+                "type": "object",
+                "required": [
+                  "amount"
+                ],
+                "properties": {
+                  "amount": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
+      "CosmosMsg_for_Empty": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "bank"
+            ],
+            "properties": {
+              "bank": {
+                "$ref": "#/definitions/BankMsg"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "$ref": "#/definitions/Empty"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "staking"
+            ],
+            "properties": {
+              "staking": {
+                "$ref": "#/definitions/StakingMsg"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "distribution"
+            ],
+            "properties": {
+              "distribution": {
+                "$ref": "#/definitions/DistributionMsg"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
+            "type": "object",
+            "required": [
+              "stargate"
+            ],
+            "properties": {
+              "stargate": {
+                "type": "object",
+                "required": [
+                  "type_url",
+                  "value"
+                ],
+                "properties": {
+                  "type_url": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "ibc"
+            ],
+            "properties": {
+              "ibc": {
+                "$ref": "#/definitions/IbcMsg"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "wasm"
+            ],
+            "properties": {
+              "wasm": {
+                "$ref": "#/definitions/WasmMsg"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "gov"
+            ],
+            "properties": {
+              "gov": {
+                "$ref": "#/definitions/GovMsg"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "DistributionMsg": {
+        "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
+        "oneOf": [
+          {
+            "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "set_withdraw_address"
+            ],
+            "properties": {
+              "set_withdraw_address": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "description": "The `withdraw_address`",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "withdraw_delegator_reward"
+            ],
+            "properties": {
+              "withdraw_delegator_reward": {
+                "type": "object",
+                "required": [
+                  "validator"
+                ],
+                "properties": {
+                  "validator": {
+                    "description": "The `validator_address`",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Duration": {
+        "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Time in seconds",
+            "type": "object",
+            "required": [
+              "time"
+            ],
+            "properties": {
+              "time": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Empty": {
+        "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "type": "object"
+      },
+      "GovMsg": {
+        "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, vote: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",
+        "oneOf": [
+          {
+            "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote"
+            ],
+            "properties": {
+              "vote": {
+                "type": "object",
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
+                "properties": {
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "vote": {
+                    "description": "The vote option.\n\nThis should be called \"option\" for consistency with Cosmos SDK. Sorry for that. See <https://github.com/CosmWasm/cosmwasm/issues/1571>.",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/VoteOption"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "IbcMsg": {
+        "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
+        "oneOf": [
+          {
+            "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
+            "type": "object",
+            "required": [
+              "transfer"
+            ],
+            "properties": {
+              "transfer": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
+                "properties": {
+                  "amount": {
+                    "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    ]
+                  },
+                  "channel_id": {
+                    "description": "exisiting channel to send the tokens over",
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "description": "when packet times out, measured on remote chain",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/IbcTimeout"
+                      }
+                    ]
+                  },
+                  "to_address": {
+                    "description": "address on the remote chain to receive these tokens",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
+            "type": "object",
+            "required": [
+              "send_packet"
+            ],
+            "properties": {
+              "send_packet": {
+                "type": "object",
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
+                "properties": {
+                  "channel_id": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "timeout": {
+                    "description": "when packet times out, measured on remote chain",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/IbcTimeout"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
+            "type": "object",
+            "required": [
+              "close_channel"
+            ],
+            "properties": {
+              "close_channel": {
+                "type": "object",
+                "required": [
+                  "channel_id"
+                ],
+                "properties": {
+                  "channel_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "IbcTimeout": {
+        "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
+        "type": "object",
+        "properties": {
+          "block": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/IbcTimeoutBlock"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Timestamp"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "IbcTimeoutBlock": {
+        "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
+        "type": "object",
+        "required": [
+          "height",
+          "revision"
+        ],
+        "properties": {
+          "height": {
+            "description": "block height after which the packet times out. the height within the given revision",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "revision": {
+            "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
+      "ModuleInstantiateInfo": {
+        "description": "Information needed to instantiate a module.",
+        "type": "object",
+        "required": [
+          "code_id",
+          "label",
+          "msg"
+        ],
+        "properties": {
+          "admin": {
+            "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Admin"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "code_id": {
+            "description": "Code ID of the contract to be instantiated.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "label": {
+            "description": "Label for the instantiated contract.",
+            "type": "string"
+          },
+          "msg": {
+            "description": "Instantiate message to be used to create the contract.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PercentageThreshold": {
+        "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
+        "oneOf": [
+          {
+            "description": "The majority of voters must vote yes for the proposal to pass.",
+            "type": "object",
+            "required": [
+              "majority"
+            ],
+            "properties": {
+              "majority": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
+            "type": "object",
+            "required": [
+              "percent"
+            ],
+            "properties": {
+              "percent": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PreProposeInfo": {
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal free of charge.",
+            "type": "object",
+            "required": [
+              "anyone_may_propose"
+            ],
+            "properties": {
+              "anyone_may_propose": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "The module specified in INFO has exclusive rights to proposal creation.",
+            "type": "object",
+            "required": [
+              "module_may_propose"
+            ],
+            "properties": {
+              "module_may_propose": {
+                "type": "object",
+                "required": [
+                  "info"
+                ],
+                "properties": {
+                  "info": {
+                    "$ref": "#/definitions/ModuleInstantiateInfo"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "SingleChoiceProposeMsg": {
+        "description": "The contents of a message to create a proposal in the single choice proposal module.\n\nWe break this type out of `ExecuteMsg` because we want pre-propose modules that interact with this contract to be able to get type checking on their propose messages.\n\nWe move this type to this package so that pre-propose modules can import it without importing dao-proposal-single with the library feature which (as it is not additive) cause the execute exports to not be included in wasm builds.",
+        "type": "object",
+        "required": [
+          "description",
+          "msgs",
+          "title"
+        ],
+        "properties": {
+          "description": {
+            "description": "A description of the proposal.",
+            "type": "string"
+          },
+          "msgs": {
+            "description": "The messages that should be executed in response to this proposal passing.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/CosmosMsg_for_Empty"
+            }
+          },
+          "proposer": {
+            "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "description": "The title of the proposal.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StakingMsg": {
+        "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
+        "oneOf": [
+          {
+            "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "delegate"
+            ],
+            "properties": {
+              "delegate": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "validator"
+                ],
+                "properties": {
+                  "amount": {
+                    "$ref": "#/definitions/Coin"
+                  },
+                  "validator": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "undelegate"
+            ],
+            "properties": {
+              "undelegate": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "validator"
+                ],
+                "properties": {
+                  "amount": {
+                    "$ref": "#/definitions/Coin"
+                  },
+                  "validator": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "redelegate"
+            ],
+            "properties": {
+              "redelegate": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
+                "properties": {
+                  "amount": {
+                    "$ref": "#/definitions/Coin"
+                  },
+                  "dst_validator": {
+                    "type": "string"
+                  },
+                  "src_validator": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Threshold": {
+        "description": "The ways a proposal may reach its passing / failing threshold.",
+        "oneOf": [
+          {
+            "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
+            "type": "object",
+            "required": [
+              "absolute_percentage"
+            ],
+            "properties": {
+              "absolute_percentage": {
+                "type": "object",
+                "required": [
+                  "percentage"
+                ],
+                "properties": {
+                  "percentage": {
+                    "$ref": "#/definitions/PercentageThreshold"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
+            "type": "object",
+            "required": [
+              "threshold_quorum"
+            ],
+            "properties": {
+              "threshold_quorum": {
+                "type": "object",
+                "required": [
+                  "quorum",
+                  "threshold"
+                ],
+                "properties": {
+                  "quorum": {
+                    "$ref": "#/definitions/PercentageThreshold"
+                  },
+                  "threshold": {
+                    "$ref": "#/definitions/PercentageThreshold"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+            "type": "object",
+            "required": [
+              "absolute_count"
+            ],
+            "properties": {
+              "absolute_count": {
+                "type": "object",
+                "required": [
+                  "threshold"
+                ],
+                "properties": {
+                  "threshold": {
+                    "$ref": "#/definitions/Uint128"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "Vote": {
+        "oneOf": [
+          {
+            "description": "Marks support for the proposal.",
+            "type": "string",
+            "enum": [
+              "yes"
+            ]
+          },
+          {
+            "description": "Marks opposition to the proposal.",
+            "type": "string",
+            "enum": [
+              "no"
+            ]
+          },
+          {
+            "description": "Marks participation but does not count towards the ratio of support / opposed.",
+            "type": "string",
+            "enum": [
+              "abstain"
+            ]
+          }
+        ]
+      },
+      "VoteOption": {
+        "type": "string",
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
+      },
+      "WasmMsg": {
+        "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
+        "oneOf": [
+          {
+            "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "execute"
+            ],
+            "properties": {
+              "execute": {
+                "type": "object",
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "msg": {
+                    "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "instantiate"
+            ],
+            "properties": {
+              "instantiate": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readbale label for the contract",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+            "type": "object",
+            "required": [
+              "migrate"
+            ],
+            "properties": {
+              "migrate": {
+                "type": "object",
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "new_code_id": {
+                    "description": "the code_id of the new logic to place in the given contract",
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
+            "type": "object",
+            "required": [
+              "update_admin"
+            ],
+            "properties": {
+              "update_admin": {
+                "type": "object",
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": "string"
+                  },
+                  "contract_addr": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
+            "type": "object",
+            "required": [
+              "clear_admin"
+            ],
+            "properties": {
+              "clear_admin": {
+                "type": "object",
+                "required": [
+                  "contract_addr"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Gets the proposal module's config.",
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Gets information about a proposal.",
+        "type": "object",
+        "required": [
+          "proposal"
+        ],
+        "properties": {
+          "proposal": {
+            "type": "object",
+            "required": [
+              "proposal_id"
+            ],
+            "properties": {
+              "proposal_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Lists all the proposals that have been cast in this module.",
+        "type": "object",
+        "required": [
+          "list_proposals"
+        ],
+        "properties": {
+          "list_proposals": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "description": "The maximum number of proposals to return as part of this query. If no limit is set a max of 30 proposals will be returned.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "description": "The proposal ID to start listing proposals after. For example, if this is set to 2 proposals with IDs 3 and higher will be returned.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Lists all of the proposals that have been cast in this module in decending order of proposal ID.",
+        "type": "object",
+        "required": [
+          "reverse_proposals"
+        ],
+        "properties": {
+          "reverse_proposals": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "description": "The maximum number of proposals to return as part of this query. If no limit is set a max of 30 proposals will be returned.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "start_before": {
+                "description": "The proposal ID to start listing proposals before. For example, if this is set to 6 proposals with IDs 5 and lower will be returned.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns a voters position on a propsal.",
+        "type": "object",
+        "required": [
+          "get_vote"
+        ],
+        "properties": {
+          "get_vote": {
+            "type": "object",
+            "required": [
+              "proposal_id",
+              "voter"
+            ],
+            "properties": {
+              "proposal_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "voter": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Lists all of the votes that have been cast on a proposal.",
+        "type": "object",
+        "required": [
+          "list_votes"
+        ],
+        "properties": {
+          "list_votes": {
+            "type": "object",
+            "required": [
+              "proposal_id"
+            ],
+            "properties": {
+              "limit": {
+                "description": "The maximum number of votes to return in response to this query. If no limit is specified a max of 30 are returned.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "proposal_id": {
+                "description": "The proposal to list the votes of.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "description": "The voter to start listing votes after. Ordering is done alphabetically.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the number of proposals that have been created in this module.",
+        "type": "object",
+        "required": [
+          "proposal_count"
+        ],
+        "properties": {
+          "proposal_count": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Gets the current proposal creation policy for this module.",
+        "type": "object",
+        "required": [
+          "proposal_creation_policy"
+        ],
+        "properties": {
+          "proposal_creation_policy": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Lists all of the consumers of proposal hooks for this module.",
+        "type": "object",
+        "required": [
+          "proposal_hooks"
+        ],
+        "properties": {
+          "proposal_hooks": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Lists all of the consumers of vote hooks for this module.",
+        "type": "object",
+        "required": [
+          "vote_hooks"
+        ],
+        "properties": {
+          "vote_hooks": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the address of the DAO this module belongs to",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the proposal ID that will be assigned to the next proposal created.",
+        "type": "object",
+        "required": [
+          "next_proposal_id"
+        ],
+        "properties": {
+          "next_proposal_id": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MigrateMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "from_v1"
+        ],
+        "properties": {
+          "from_v1": {
+            "type": "object",
+            "required": [
+              "close_proposal_on_execution_failure",
+              "pre_propose_info"
+            ],
+            "properties": {
+              "close_proposal_on_execution_failure": {
+                "description": "This field was not present in DAO DAO v1. To migrate, a value must be specified.\n\nIf set to true proposals will be closed if their execution fails. Otherwise, proposals will remain open after execution failure. For example, with this enabled a proposal to send 5 tokens out of a DAO's treasury with 4 tokens would be closed when it is executed. With this disabled, that same proposal would remain open until the DAO's treasury was large enough for it to be executed.",
+                "type": "boolean"
+              },
+              "pre_propose_info": {
+                "description": "This field was not present in DAO DAO v1. To migrate, a value must be specified.\n\nThis contains information about how a pre-propose module may be configured. If set to \"AnyoneMayPropose\", there will be no pre-propose module and consequently, no deposit or membership checks when submitting a proposal. The \"ModuleMayPropose\" option allows for instantiating a prepropose module which will handle deposit verification and return logic.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/PreProposeInfo"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "from_compatible"
+        ],
+        "properties": {
+          "from_compatible": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Admin": {
+        "description": "Information about the CosmWasm level admin of a contract. Used in conjunction with `ModuleInstantiateInfo` to instantiate modules.",
+        "oneOf": [
+          {
+            "description": "Set the admin to a specified address.",
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "object",
+                "required": [
+                  "addr"
+                ],
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Sets the admin as the core module address.",
+            "type": "object",
+            "required": [
+              "core_module"
+            ],
+            "properties": {
+              "core_module": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "ModuleInstantiateInfo": {
+        "description": "Information needed to instantiate a module.",
+        "type": "object",
+        "required": [
+          "code_id",
+          "label",
+          "msg"
+        ],
+        "properties": {
+          "admin": {
+            "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Admin"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "code_id": {
+            "description": "Code ID of the contract to be instantiated.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "label": {
+            "description": "Label for the instantiated contract.",
+            "type": "string"
+          },
+          "msg": {
+            "description": "Instantiate message to be used to create the contract.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PreProposeInfo": {
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal free of charge.",
+            "type": "object",
+            "required": [
+              "anyone_may_propose"
+            ],
+            "properties": {
+              "anyone_may_propose": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "The module specified in INFO has exclusive rights to proposal creation.",
+            "type": "object",
+            "required": [
+              "module_may_propose"
+            ],
+            "properties": {
+              "module_may_propose": {
+                "type": "object",
+                "required": [
+                  "info"
+                ],
+                "properties": {
+                  "info": {
+                    "$ref": "#/definitions/ModuleInstantiateInfo"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "sudo": null,
+  "responses": {
+    "config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "The governance module's configuration.",
+      "type": "object",
+      "required": [
+        "allow_revoting",
+        "close_proposal_on_execution_failure",
+        "dao",
+        "max_voting_period",
+        "only_members_execute",
+        "threshold"
+      ],
+      "properties": {
+        "allow_revoting": {
+          "description": "Allows changing votes before the proposal expires. If this is enabled proposals will not be able to complete early as final vote information is not known until the time of proposal expiration.",
+          "type": "boolean"
+        },
+        "close_proposal_on_execution_failure": {
+          "description": "If set to true proposals will be closed if their execution fails. Otherwise, proposals will remain open after execution failure. For example, with this enabled a proposal to send 5 tokens out of a DAO's treasury with 4 tokens would be closed when it is executed. With this disabled, that same proposal would remain open until the DAO's treasury was large enough for it to be executed.",
+          "type": "boolean"
+        },
+        "dao": {
+          "description": "The address of the DAO that this governance module is associated with.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
+        },
+        "max_voting_period": {
+          "description": "The default maximum amount of time a proposal may be voted on before expiring.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            }
+          ]
+        },
+        "min_voting_period": {
+          "description": "The minimum amount of time a proposal must be open before passing. A proposal may fail before this amount of time has elapsed, but it will not pass. This can be useful for preventing governance attacks wherein an attacker aquires a large number of tokens and forces a proposal through.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "only_members_execute": {
+          "description": "If set to true only members may execute passed proposals. Otherwise, any address may execute a passed proposal.",
+          "type": "boolean"
+        },
+        "threshold": {
+          "description": "The threshold a proposal must reach to complete.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Threshold"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "Duration": {
+          "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Time in seconds",
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PercentageThreshold": {
+          "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
+          "oneOf": [
+            {
+              "description": "The majority of voters must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "majority"
+              ],
+              "properties": {
+                "majority": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "percent"
+              ],
+              "properties": {
+                "percent": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Threshold": {
+          "description": "The ways a proposal may reach its passing / failing threshold.",
+          "oneOf": [
+            {
+              "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "absolute_percentage"
+              ],
+              "properties": {
+                "absolute_percentage": {
+                  "type": "object",
+                  "required": [
+                    "percentage"
+                  ],
+                  "properties": {
+                    "percentage": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "threshold_quorum"
+              ],
+              "properties": {
+                "threshold_quorum": {
+                  "type": "object",
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
+                  "properties": {
+                    "quorum": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    },
+                    "threshold": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+              "type": "object",
+              "required": [
+                "absolute_count"
+              ],
+              "properties": {
+                "absolute_count": {
+                  "type": "object",
+                  "required": [
+                    "threshold"
+                  ],
+                  "properties": {
+                    "threshold": {
+                      "$ref": "#/definitions/Uint128"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "dao": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_vote": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "VoteResponse",
+      "description": "Information about a vote.",
+      "type": "object",
+      "properties": {
+        "vote": {
+          "description": "None if no such vote, Some otherwise.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VoteInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Vote": {
+          "oneOf": [
+            {
+              "description": "Marks support for the proposal.",
+              "type": "string",
+              "enum": [
+                "yes"
+              ]
+            },
+            {
+              "description": "Marks opposition to the proposal.",
+              "type": "string",
+              "enum": [
+                "no"
+              ]
+            },
+            {
+              "description": "Marks participation but does not count towards the ratio of support / opposed.",
+              "type": "string",
+              "enum": [
+                "abstain"
+              ]
+            }
+          ]
+        },
+        "VoteInfo": {
+          "description": "Information about a vote that was cast.",
+          "type": "object",
+          "required": [
+            "power",
+            "vote",
+            "voter"
+          ],
+          "properties": {
+            "power": {
+              "description": "The voting power behind the vote.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "rationale": {
+              "description": "Address-specified rationale for the vote.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vote": {
+              "description": "Position on the vote.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Vote"
+                }
+              ]
+            },
+            "voter": {
+              "description": "The address that voted.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "list_proposals": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProposalListResponse",
+      "description": "A list of proposals returned by `ListProposals` and `ReverseProposals`.",
+      "type": "object",
+      "required": [
+        "proposals"
+      ],
+      "properties": {
+        "proposals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProposalResponse"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "BankMsg": {
+          "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "send"
+              ],
+              "properties": {
+                "send": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "to_address": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
+              "type": "object",
+              "required": [
+                "burn"
+              ],
+              "properties": {
+                "burn": {
+                  "type": "object",
+                  "required": [
+                    "amount"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          }
+        },
+        "CosmosMsg_for_Empty": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "bank"
+              ],
+              "properties": {
+                "bank": {
+                  "$ref": "#/definitions/BankMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "$ref": "#/definitions/Empty"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "staking"
+              ],
+              "properties": {
+                "staking": {
+                  "$ref": "#/definitions/StakingMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "distribution"
+              ],
+              "properties": {
+                "distribution": {
+                  "$ref": "#/definitions/DistributionMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
+              "type": "object",
+              "required": [
+                "stargate"
+              ],
+              "properties": {
+                "stargate": {
+                  "type": "object",
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
+                  "properties": {
+                    "type_url": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "ibc"
+              ],
+              "properties": {
+                "ibc": {
+                  "$ref": "#/definitions/IbcMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "wasm"
+              ],
+              "properties": {
+                "wasm": {
+                  "$ref": "#/definitions/WasmMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "gov"
+              ],
+              "properties": {
+                "gov": {
+                  "$ref": "#/definitions/GovMsg"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "DistributionMsg": {
+          "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "set_withdraw_address"
+              ],
+              "properties": {
+                "set_withdraw_address": {
+                  "type": "object",
+                  "required": [
+                    "address"
+                  ],
+                  "properties": {
+                    "address": {
+                      "description": "The `withdraw_address`",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "withdraw_delegator_reward"
+              ],
+              "properties": {
+                "withdraw_delegator_reward": {
+                  "type": "object",
+                  "required": [
+                    "validator"
+                  ],
+                  "properties": {
+                    "validator": {
+                      "description": "The `validator_address`",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Empty": {
+          "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+          "type": "object"
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "GovMsg": {
+          "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, vote: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",
+          "oneOf": [
+            {
+              "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote"
+              ],
+              "properties": {
+                "vote": {
+                  "type": "object",
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
+                  "properties": {
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "vote": {
+                      "description": "The vote option.\n\nThis should be called \"option\" for consistency with Cosmos SDK. Sorry for that. See <https://github.com/CosmWasm/cosmwasm/issues/1571>.",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/VoteOption"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcMsg": {
+          "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
+          "oneOf": [
+            {
+              "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
+              "type": "object",
+              "required": [
+                "transfer"
+              ],
+              "properties": {
+                "transfer": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Coin"
+                        }
+                      ]
+                    },
+                    "channel_id": {
+                      "description": "exisiting channel to send the tokens over",
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "when packet times out, measured on remote chain",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/IbcTimeout"
+                        }
+                      ]
+                    },
+                    "to_address": {
+                      "description": "address on the remote chain to receive these tokens",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
+              "type": "object",
+              "required": [
+                "send_packet"
+              ],
+              "properties": {
+                "send_packet": {
+                  "type": "object",
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
+                  "properties": {
+                    "channel_id": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "$ref": "#/definitions/Binary"
+                    },
+                    "timeout": {
+                      "description": "when packet times out, measured on remote chain",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/IbcTimeout"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
+              "type": "object",
+              "required": [
+                "close_channel"
+              ],
+              "properties": {
+                "close_channel": {
+                  "type": "object",
+                  "required": [
+                    "channel_id"
+                  ],
+                  "properties": {
+                    "channel_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcTimeout": {
+          "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
+          "type": "object",
+          "properties": {
+            "block": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/IbcTimeoutBlock"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timestamp": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "IbcTimeoutBlock": {
+          "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
+          "type": "object",
+          "required": [
+            "height",
+            "revision"
+          ],
+          "properties": {
+            "height": {
+              "description": "block height after which the packet times out. the height within the given revision",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "revision": {
+              "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        "PercentageThreshold": {
+          "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
+          "oneOf": [
+            {
+              "description": "The majority of voters must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "majority"
+              ],
+              "properties": {
+                "majority": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "percent"
+              ],
+              "properties": {
+                "percent": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ProposalResponse": {
+          "description": "Information about a proposal returned by proposal queries.",
+          "type": "object",
+          "required": [
+            "id",
+            "proposal"
+          ],
+          "properties": {
+            "id": {
+              "description": "The ID of the proposal being returned.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "proposal": {
+              "$ref": "#/definitions/SingleChoiceProposal"
+            }
+          },
+          "additionalProperties": false
+        },
+        "SingleChoiceProposal": {
+          "type": "object",
+          "required": [
+            "allow_revoting",
+            "description",
+            "expiration",
+            "msgs",
+            "proposer",
+            "start_height",
+            "status",
+            "threshold",
+            "title",
+            "total_power",
+            "votes"
+          ],
+          "properties": {
+            "allow_revoting": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "expiration": {
+              "description": "The the time at which this proposal will expire and close for additional votes.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                }
+              ]
+            },
+            "min_voting_period": {
+              "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "msgs": {
+              "description": "The messages that will be executed should this proposal pass.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
+            },
+            "proposer": {
+              "description": "The address that created this proposal.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            },
+            "start_height": {
+              "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "status": {
+              "$ref": "#/definitions/Status"
+            },
+            "threshold": {
+              "description": "The threshold at which this proposal will pass.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "total_power": {
+              "description": "The total amount of voting power at the time of this proposal's creation.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "votes": {
+              "$ref": "#/definitions/Votes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "StakingMsg": {
+          "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "delegate"
+              ],
+              "properties": {
+                "delegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "undelegate"
+              ],
+              "properties": {
+                "undelegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "redelegate"
+              ],
+              "properties": {
+                "redelegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "dst_validator": {
+                      "type": "string"
+                    },
+                    "src_validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Status": {
+          "oneOf": [
+            {
+              "description": "The proposal is open for voting.",
+              "type": "string",
+              "enum": [
+                "open"
+              ]
+            },
+            {
+              "description": "The proposal has been rejected.",
+              "type": "string",
+              "enum": [
+                "rejected"
+              ]
+            },
+            {
+              "description": "The proposal has been passed but has not been executed.",
+              "type": "string",
+              "enum": [
+                "passed"
+              ]
+            },
+            {
+              "description": "The proposal has been passed and executed.",
+              "type": "string",
+              "enum": [
+                "executed"
+              ]
+            },
+            {
+              "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
+              "type": "string",
+              "enum": [
+                "closed"
+              ]
+            },
+            {
+              "description": "The proposal's execution failed.",
+              "type": "string",
+              "enum": [
+                "execution_failed"
+              ]
+            }
+          ]
+        },
+        "Threshold": {
+          "description": "The ways a proposal may reach its passing / failing threshold.",
+          "oneOf": [
+            {
+              "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "absolute_percentage"
+              ],
+              "properties": {
+                "absolute_percentage": {
+                  "type": "object",
+                  "required": [
+                    "percentage"
+                  ],
+                  "properties": {
+                    "percentage": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "threshold_quorum"
+              ],
+              "properties": {
+                "threshold_quorum": {
+                  "type": "object",
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
+                  "properties": {
+                    "quorum": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    },
+                    "threshold": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+              "type": "object",
+              "required": [
+                "absolute_count"
+              ],
+              "properties": {
+                "absolute_count": {
+                  "type": "object",
+                  "required": [
+                    "threshold"
+                  ],
+                  "properties": {
+                    "threshold": {
+                      "$ref": "#/definitions/Uint128"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        },
+        "VoteOption": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
+        },
+        "Votes": {
+          "type": "object",
+          "required": [
+            "abstain",
+            "no",
+            "yes"
+          ],
+          "properties": {
+            "abstain": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "no": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "yes": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        },
+        "WasmMsg": {
+          "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
+          "oneOf": [
+            {
+              "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "execute"
+              ],
+              "properties": {
+                "execute": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "msg": {
+                      "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "instantiate"
+              ],
+              "properties": {
+                "instantiate": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readbale label for the contract",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "migrate"
+              ],
+              "properties": {
+                "migrate": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "new_code_id": {
+                      "description": "the code_id of the new logic to place in the given contract",
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
+              "type": "object",
+              "required": [
+                "update_admin"
+              ],
+              "properties": {
+                "update_admin": {
+                  "type": "object",
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": "string"
+                    },
+                    "contract_addr": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
+              "type": "object",
+              "required": [
+                "clear_admin"
+              ],
+              "properties": {
+                "clear_admin": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "list_votes": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "VoteListResponse",
+      "description": "Information about the votes for a proposal.",
+      "type": "object",
+      "required": [
+        "votes"
+      ],
+      "properties": {
+        "votes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VoteInfo"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Vote": {
+          "oneOf": [
+            {
+              "description": "Marks support for the proposal.",
+              "type": "string",
+              "enum": [
+                "yes"
+              ]
+            },
+            {
+              "description": "Marks opposition to the proposal.",
+              "type": "string",
+              "enum": [
+                "no"
+              ]
+            },
+            {
+              "description": "Marks participation but does not count towards the ratio of support / opposed.",
+              "type": "string",
+              "enum": [
+                "abstain"
+              ]
+            }
+          ]
+        },
+        "VoteInfo": {
+          "description": "Information about a vote that was cast.",
+          "type": "object",
+          "required": [
+            "power",
+            "vote",
+            "voter"
+          ],
+          "properties": {
+            "power": {
+              "description": "The voting power behind the vote.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "rationale": {
+              "description": "Address-specified rationale for the vote.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vote": {
+              "description": "Position on the vote.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Vote"
+                }
+              ]
+            },
+            "voter": {
+              "description": "The address that voted.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "next_proposal_id": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "uint64",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "proposal": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProposalResponse",
+      "description": "Information about a proposal returned by proposal queries.",
+      "type": "object",
+      "required": [
+        "id",
+        "proposal"
+      ],
+      "properties": {
+        "id": {
+          "description": "The ID of the proposal being returned.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "proposal": {
+          "$ref": "#/definitions/SingleChoiceProposal"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "BankMsg": {
+          "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "send"
+              ],
+              "properties": {
+                "send": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "to_address": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
+              "type": "object",
+              "required": [
+                "burn"
+              ],
+              "properties": {
+                "burn": {
+                  "type": "object",
+                  "required": [
+                    "amount"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          }
+        },
+        "CosmosMsg_for_Empty": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "bank"
+              ],
+              "properties": {
+                "bank": {
+                  "$ref": "#/definitions/BankMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "$ref": "#/definitions/Empty"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "staking"
+              ],
+              "properties": {
+                "staking": {
+                  "$ref": "#/definitions/StakingMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "distribution"
+              ],
+              "properties": {
+                "distribution": {
+                  "$ref": "#/definitions/DistributionMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
+              "type": "object",
+              "required": [
+                "stargate"
+              ],
+              "properties": {
+                "stargate": {
+                  "type": "object",
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
+                  "properties": {
+                    "type_url": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "ibc"
+              ],
+              "properties": {
+                "ibc": {
+                  "$ref": "#/definitions/IbcMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "wasm"
+              ],
+              "properties": {
+                "wasm": {
+                  "$ref": "#/definitions/WasmMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "gov"
+              ],
+              "properties": {
+                "gov": {
+                  "$ref": "#/definitions/GovMsg"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "DistributionMsg": {
+          "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "set_withdraw_address"
+              ],
+              "properties": {
+                "set_withdraw_address": {
+                  "type": "object",
+                  "required": [
+                    "address"
+                  ],
+                  "properties": {
+                    "address": {
+                      "description": "The `withdraw_address`",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "withdraw_delegator_reward"
+              ],
+              "properties": {
+                "withdraw_delegator_reward": {
+                  "type": "object",
+                  "required": [
+                    "validator"
+                  ],
+                  "properties": {
+                    "validator": {
+                      "description": "The `validator_address`",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Empty": {
+          "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+          "type": "object"
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "GovMsg": {
+          "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, vote: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",
+          "oneOf": [
+            {
+              "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote"
+              ],
+              "properties": {
+                "vote": {
+                  "type": "object",
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
+                  "properties": {
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "vote": {
+                      "description": "The vote option.\n\nThis should be called \"option\" for consistency with Cosmos SDK. Sorry for that. See <https://github.com/CosmWasm/cosmwasm/issues/1571>.",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/VoteOption"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcMsg": {
+          "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
+          "oneOf": [
+            {
+              "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
+              "type": "object",
+              "required": [
+                "transfer"
+              ],
+              "properties": {
+                "transfer": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Coin"
+                        }
+                      ]
+                    },
+                    "channel_id": {
+                      "description": "exisiting channel to send the tokens over",
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "when packet times out, measured on remote chain",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/IbcTimeout"
+                        }
+                      ]
+                    },
+                    "to_address": {
+                      "description": "address on the remote chain to receive these tokens",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
+              "type": "object",
+              "required": [
+                "send_packet"
+              ],
+              "properties": {
+                "send_packet": {
+                  "type": "object",
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
+                  "properties": {
+                    "channel_id": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "$ref": "#/definitions/Binary"
+                    },
+                    "timeout": {
+                      "description": "when packet times out, measured on remote chain",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/IbcTimeout"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
+              "type": "object",
+              "required": [
+                "close_channel"
+              ],
+              "properties": {
+                "close_channel": {
+                  "type": "object",
+                  "required": [
+                    "channel_id"
+                  ],
+                  "properties": {
+                    "channel_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcTimeout": {
+          "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
+          "type": "object",
+          "properties": {
+            "block": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/IbcTimeoutBlock"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timestamp": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "IbcTimeoutBlock": {
+          "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
+          "type": "object",
+          "required": [
+            "height",
+            "revision"
+          ],
+          "properties": {
+            "height": {
+              "description": "block height after which the packet times out. the height within the given revision",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "revision": {
+              "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        "PercentageThreshold": {
+          "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
+          "oneOf": [
+            {
+              "description": "The majority of voters must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "majority"
+              ],
+              "properties": {
+                "majority": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "percent"
+              ],
+              "properties": {
+                "percent": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "SingleChoiceProposal": {
+          "type": "object",
+          "required": [
+            "allow_revoting",
+            "description",
+            "expiration",
+            "msgs",
+            "proposer",
+            "start_height",
+            "status",
+            "threshold",
+            "title",
+            "total_power",
+            "votes"
+          ],
+          "properties": {
+            "allow_revoting": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "expiration": {
+              "description": "The the time at which this proposal will expire and close for additional votes.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                }
+              ]
+            },
+            "min_voting_period": {
+              "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "msgs": {
+              "description": "The messages that will be executed should this proposal pass.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
+            },
+            "proposer": {
+              "description": "The address that created this proposal.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            },
+            "start_height": {
+              "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "status": {
+              "$ref": "#/definitions/Status"
+            },
+            "threshold": {
+              "description": "The threshold at which this proposal will pass.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "total_power": {
+              "description": "The total amount of voting power at the time of this proposal's creation.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "votes": {
+              "$ref": "#/definitions/Votes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "StakingMsg": {
+          "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "delegate"
+              ],
+              "properties": {
+                "delegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "undelegate"
+              ],
+              "properties": {
+                "undelegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "redelegate"
+              ],
+              "properties": {
+                "redelegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "dst_validator": {
+                      "type": "string"
+                    },
+                    "src_validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Status": {
+          "oneOf": [
+            {
+              "description": "The proposal is open for voting.",
+              "type": "string",
+              "enum": [
+                "open"
+              ]
+            },
+            {
+              "description": "The proposal has been rejected.",
+              "type": "string",
+              "enum": [
+                "rejected"
+              ]
+            },
+            {
+              "description": "The proposal has been passed but has not been executed.",
+              "type": "string",
+              "enum": [
+                "passed"
+              ]
+            },
+            {
+              "description": "The proposal has been passed and executed.",
+              "type": "string",
+              "enum": [
+                "executed"
+              ]
+            },
+            {
+              "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
+              "type": "string",
+              "enum": [
+                "closed"
+              ]
+            },
+            {
+              "description": "The proposal's execution failed.",
+              "type": "string",
+              "enum": [
+                "execution_failed"
+              ]
+            }
+          ]
+        },
+        "Threshold": {
+          "description": "The ways a proposal may reach its passing / failing threshold.",
+          "oneOf": [
+            {
+              "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "absolute_percentage"
+              ],
+              "properties": {
+                "absolute_percentage": {
+                  "type": "object",
+                  "required": [
+                    "percentage"
+                  ],
+                  "properties": {
+                    "percentage": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "threshold_quorum"
+              ],
+              "properties": {
+                "threshold_quorum": {
+                  "type": "object",
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
+                  "properties": {
+                    "quorum": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    },
+                    "threshold": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+              "type": "object",
+              "required": [
+                "absolute_count"
+              ],
+              "properties": {
+                "absolute_count": {
+                  "type": "object",
+                  "required": [
+                    "threshold"
+                  ],
+                  "properties": {
+                    "threshold": {
+                      "$ref": "#/definitions/Uint128"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        },
+        "VoteOption": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
+        },
+        "Votes": {
+          "type": "object",
+          "required": [
+            "abstain",
+            "no",
+            "yes"
+          ],
+          "properties": {
+            "abstain": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "no": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "yes": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        },
+        "WasmMsg": {
+          "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
+          "oneOf": [
+            {
+              "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "execute"
+              ],
+              "properties": {
+                "execute": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "msg": {
+                      "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "instantiate"
+              ],
+              "properties": {
+                "instantiate": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readbale label for the contract",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "migrate"
+              ],
+              "properties": {
+                "migrate": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "new_code_id": {
+                      "description": "the code_id of the new logic to place in the given contract",
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
+              "type": "object",
+              "required": [
+                "update_admin"
+              ],
+              "properties": {
+                "update_admin": {
+                  "type": "object",
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": "string"
+                    },
+                    "contract_addr": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
+              "type": "object",
+              "required": [
+                "clear_admin"
+              ],
+              "properties": {
+                "clear_admin": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "proposal_count": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "uint64",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "proposal_creation_policy": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProposalCreationPolicy",
+      "oneOf": [
+        {
+          "description": "Anyone may create a proposal, free of charge.",
+          "type": "object",
+          "required": [
+            "anyone"
+          ],
+          "properties": {
+            "anyone": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Only ADDR may create proposals. It is expected that ADDR is a pre-propose module, though we only require that it is a valid address.",
+          "type": "object",
+          "required": [
+            "module"
+          ],
+          "properties": {
+            "module": {
+              "type": "object",
+              "required": [
+                "addr"
+              ],
+              "properties": {
+                "addr": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    },
+    "proposal_hooks": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "HooksResponse",
+      "type": "object",
+      "required": [
+        "hooks"
+      ],
+      "properties": {
+        "hooks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "reverse_proposals": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProposalListResponse",
+      "description": "A list of proposals returned by `ListProposals` and `ReverseProposals`.",
+      "type": "object",
+      "required": [
+        "proposals"
+      ],
+      "properties": {
+        "proposals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProposalResponse"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "BankMsg": {
+          "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "send"
+              ],
+              "properties": {
+                "send": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "to_address": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
+              "type": "object",
+              "required": [
+                "burn"
+              ],
+              "properties": {
+                "burn": {
+                  "type": "object",
+                  "required": [
+                    "amount"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          }
+        },
+        "CosmosMsg_for_Empty": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "bank"
+              ],
+              "properties": {
+                "bank": {
+                  "$ref": "#/definitions/BankMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "$ref": "#/definitions/Empty"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "staking"
+              ],
+              "properties": {
+                "staking": {
+                  "$ref": "#/definitions/StakingMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "distribution"
+              ],
+              "properties": {
+                "distribution": {
+                  "$ref": "#/definitions/DistributionMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
+              "type": "object",
+              "required": [
+                "stargate"
+              ],
+              "properties": {
+                "stargate": {
+                  "type": "object",
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
+                  "properties": {
+                    "type_url": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "ibc"
+              ],
+              "properties": {
+                "ibc": {
+                  "$ref": "#/definitions/IbcMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "wasm"
+              ],
+              "properties": {
+                "wasm": {
+                  "$ref": "#/definitions/WasmMsg"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "gov"
+              ],
+              "properties": {
+                "gov": {
+                  "$ref": "#/definitions/GovMsg"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "DistributionMsg": {
+          "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "set_withdraw_address"
+              ],
+              "properties": {
+                "set_withdraw_address": {
+                  "type": "object",
+                  "required": [
+                    "address"
+                  ],
+                  "properties": {
+                    "address": {
+                      "description": "The `withdraw_address`",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "withdraw_delegator_reward"
+              ],
+              "properties": {
+                "withdraw_delegator_reward": {
+                  "type": "object",
+                  "required": [
+                    "validator"
+                  ],
+                  "properties": {
+                    "validator": {
+                      "description": "The `validator_address`",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Empty": {
+          "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+          "type": "object"
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "GovMsg": {
+          "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, vote: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",
+          "oneOf": [
+            {
+              "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote"
+              ],
+              "properties": {
+                "vote": {
+                  "type": "object",
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
+                  "properties": {
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "vote": {
+                      "description": "The vote option.\n\nThis should be called \"option\" for consistency with Cosmos SDK. Sorry for that. See <https://github.com/CosmWasm/cosmwasm/issues/1571>.",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/VoteOption"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcMsg": {
+          "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
+          "oneOf": [
+            {
+              "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
+              "type": "object",
+              "required": [
+                "transfer"
+              ],
+              "properties": {
+                "transfer": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Coin"
+                        }
+                      ]
+                    },
+                    "channel_id": {
+                      "description": "exisiting channel to send the tokens over",
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "when packet times out, measured on remote chain",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/IbcTimeout"
+                        }
+                      ]
+                    },
+                    "to_address": {
+                      "description": "address on the remote chain to receive these tokens",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
+              "type": "object",
+              "required": [
+                "send_packet"
+              ],
+              "properties": {
+                "send_packet": {
+                  "type": "object",
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
+                  "properties": {
+                    "channel_id": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "$ref": "#/definitions/Binary"
+                    },
+                    "timeout": {
+                      "description": "when packet times out, measured on remote chain",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/IbcTimeout"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
+              "type": "object",
+              "required": [
+                "close_channel"
+              ],
+              "properties": {
+                "close_channel": {
+                  "type": "object",
+                  "required": [
+                    "channel_id"
+                  ],
+                  "properties": {
+                    "channel_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcTimeout": {
+          "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
+          "type": "object",
+          "properties": {
+            "block": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/IbcTimeoutBlock"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timestamp": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "IbcTimeoutBlock": {
+          "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
+          "type": "object",
+          "required": [
+            "height",
+            "revision"
+          ],
+          "properties": {
+            "height": {
+              "description": "block height after which the packet times out. the height within the given revision",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "revision": {
+              "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        "PercentageThreshold": {
+          "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
+          "oneOf": [
+            {
+              "description": "The majority of voters must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "majority"
+              ],
+              "properties": {
+                "majority": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
+              "type": "object",
+              "required": [
+                "percent"
+              ],
+              "properties": {
+                "percent": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ProposalResponse": {
+          "description": "Information about a proposal returned by proposal queries.",
+          "type": "object",
+          "required": [
+            "id",
+            "proposal"
+          ],
+          "properties": {
+            "id": {
+              "description": "The ID of the proposal being returned.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "proposal": {
+              "$ref": "#/definitions/SingleChoiceProposal"
+            }
+          },
+          "additionalProperties": false
+        },
+        "SingleChoiceProposal": {
+          "type": "object",
+          "required": [
+            "allow_revoting",
+            "description",
+            "expiration",
+            "msgs",
+            "proposer",
+            "start_height",
+            "status",
+            "threshold",
+            "title",
+            "total_power",
+            "votes"
+          ],
+          "properties": {
+            "allow_revoting": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "expiration": {
+              "description": "The the time at which this proposal will expire and close for additional votes.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                }
+              ]
+            },
+            "min_voting_period": {
+              "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "msgs": {
+              "description": "The messages that will be executed should this proposal pass.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
+            },
+            "proposer": {
+              "description": "The address that created this proposal.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            },
+            "start_height": {
+              "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "status": {
+              "$ref": "#/definitions/Status"
+            },
+            "threshold": {
+              "description": "The threshold at which this proposal will pass.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "total_power": {
+              "description": "The total amount of voting power at the time of this proposal's creation.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "votes": {
+              "$ref": "#/definitions/Votes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "StakingMsg": {
+          "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
+          "oneOf": [
+            {
+              "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "delegate"
+              ],
+              "properties": {
+                "delegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "undelegate"
+              ],
+              "properties": {
+                "undelegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "redelegate"
+              ],
+              "properties": {
+                "redelegate": {
+                  "type": "object",
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
+                  "properties": {
+                    "amount": {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    "dst_validator": {
+                      "type": "string"
+                    },
+                    "src_validator": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Status": {
+          "oneOf": [
+            {
+              "description": "The proposal is open for voting.",
+              "type": "string",
+              "enum": [
+                "open"
+              ]
+            },
+            {
+              "description": "The proposal has been rejected.",
+              "type": "string",
+              "enum": [
+                "rejected"
+              ]
+            },
+            {
+              "description": "The proposal has been passed but has not been executed.",
+              "type": "string",
+              "enum": [
+                "passed"
+              ]
+            },
+            {
+              "description": "The proposal has been passed and executed.",
+              "type": "string",
+              "enum": [
+                "executed"
+              ]
+            },
+            {
+              "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
+              "type": "string",
+              "enum": [
+                "closed"
+              ]
+            },
+            {
+              "description": "The proposal's execution failed.",
+              "type": "string",
+              "enum": [
+                "execution_failed"
+              ]
+            }
+          ]
+        },
+        "Threshold": {
+          "description": "The ways a proposal may reach its passing / failing threshold.",
+          "oneOf": [
+            {
+              "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "absolute_percentage"
+              ],
+              "properties": {
+                "absolute_percentage": {
+                  "type": "object",
+                  "required": [
+                    "percentage"
+                  ],
+                  "properties": {
+                    "percentage": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
+              "type": "object",
+              "required": [
+                "threshold_quorum"
+              ],
+              "properties": {
+                "threshold_quorum": {
+                  "type": "object",
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
+                  "properties": {
+                    "quorum": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    },
+                    "threshold": {
+                      "$ref": "#/definitions/PercentageThreshold"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+              "type": "object",
+              "required": [
+                "absolute_count"
+              ],
+              "properties": {
+                "absolute_count": {
+                  "type": "object",
+                  "required": [
+                    "threshold"
+                  ],
+                  "properties": {
+                    "threshold": {
+                      "$ref": "#/definitions/Uint128"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        },
+        "VoteOption": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
+        },
+        "Votes": {
+          "type": "object",
+          "required": [
+            "abstain",
+            "no",
+            "yes"
+          ],
+          "properties": {
+            "abstain": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "no": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "yes": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        },
+        "WasmMsg": {
+          "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
+          "oneOf": [
+            {
+              "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "execute"
+              ],
+              "properties": {
+                "execute": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "msg": {
+                      "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "instantiate"
+              ],
+              "properties": {
+                "instantiate": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readbale label for the contract",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+              "type": "object",
+              "required": [
+                "migrate"
+              ],
+              "properties": {
+                "migrate": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "new_code_id": {
+                      "description": "the code_id of the new logic to place in the given contract",
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
+              "type": "object",
+              "required": [
+                "update_admin"
+              ],
+              "properties": {
+                "update_admin": {
+                  "type": "object",
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": "string"
+                    },
+                    "contract_addr": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
+              "type": "object",
+              "required": [
+                "clear_admin"
+              ],
+              "properties": {
+                "clear_admin": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "vote_hooks": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "HooksResponse",
+      "type": "object",
+      "required": [
+        "hooks"
+      ],
+      "properties": {
+        "hooks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -60,8 +60,6 @@
     },
     "required": [
       "code_id",
-      "source",
-      "source_builder",
       "schema",
       "contacts"
     ]

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
       "code_id": {

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "code_id": {
+        "type": "integer"
+      },
+      "source": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "license": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "repository",
+          "tag",
+          "license"
+        ]
+      },
+      "source_builder": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "contract_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "image",
+          "tag",
+          "contract_name"
+        ]
+      },
+      "schema": {
+        "type": "string"
+      },
+      "contacts": {
+        "type": "array",
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "required": [
+      "code_id",
+      "source",
+      "source_builder",
+      "schema",
+      "contacts"
+    ]
+  }


### PR DESCRIPTION
- Adding `metadata.schema.json` 
- Adding github workflow to ensure that `metadata.json`  matches the required schema

For testing it out,
- Adding dao-dao single proposal contract metadata and schema 

Note:

There is some extra actions in the github workflow which were implemented to do source code & builder checks by matching the checksum. But the actions take tooo long. ~20mins. Commented out for now. Will enable them/optimize them when needed