### PR TITLE
ci: fixing validation checks for metadata.json

### DIFF
--- a/.github/workflows/contracts_schema_check.yml
+++ b/.github/workflows/contracts_schema_check.yml
@@ -44,6 +44,7 @@ jobs:
     name: Validate ${{ matrix.file }}
     needs: [get-modified-files]
     runs-on: ubuntu-latest
+    if: ${{ needs.get-modified-files.outputs.contracts_files != '[]' && needs.get-modified-files.outputs.contracts_files != '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/contracts_schema_check.yml
+++ b/.github/workflows/contracts_schema_check.yml
@@ -65,6 +65,7 @@ jobs:
     name: Validate contract instances
     needs: [get-modified-files]
     runs-on: ubuntu-latest
+    if: ${{ needs.get-modified-files.outputs.contracts_files != '[]' && needs.get-modified-files.outputs.contracts_files != '' }}
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -44,6 +44,7 @@ jobs:
     name: Validate ${{ matrix.file }}
     needs: [get-modified-files]
     runs-on: ubuntu-latest
+    if: ${{ needs.get-modified-files.outputs.metadata_files != '[]' && needs.get-modified-files.outputs.metadata_files != '' }}
     strategy:
       fail-fast: false
       matrix: 

--- a/.github/workflows/metadata_schema_check.yml
+++ b/.github/workflows/metadata_schema_check.yml
@@ -1,4 +1,4 @@
-name: Metadata Check
+name: metadata.json validation
 
 on:
   pull_request:
@@ -6,19 +6,59 @@ on:
       - main
 
 jobs:
-  validate-json-schema:
-    name: Validate the Metadata JSON schema
+  get-modified-files:
+    name: Get modified metadata.json 
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
 
     steps:
-      - uses: actions/checkout@v3  
-      - name: Validate JSON
-        uses: GrantBirki/json-yaml-validate@v2.3.1
-        with:
-          base_dir: mainnet
-          json_schema: ./schemas/metadata.schema.json
-          json_exclude_regex: ^(main|test){1}net\/\d\/(?!metadata\.json$).*
-          use_gitignore: false
+      # Get all the files which have been changed in this PR
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+
+      # Output all the files which were changed and match the path mainnet/*/metadata.json
+      - name: Set changed metadata.json files
+        id: setfiles
+        run: |
+          FILES_ARRAY=""
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            FILE_NAME=$(basename $file)
+            if [ $FILE_NAME != "metadata.json" ]; then
+                continue
+            fi
+            NETWORK=$(echo $file | cut -d '/' -f 1)
+            if [[ "$NETWORK" == "mainnet" ]]; then
+              FILES_ARRAY+="$file,"
+            else
+              continue
+            fi
+          done
+          FILES_ARRAY=$(echo $FILES_ARRAY | jq -R -s -c 'split(",")[:-1]')
+          echo "metadata_files=${FILES_ARRAY}" >> $GITHUB_OUTPUT
+    outputs:
+      metadata_files: ${{ steps.setfiles.outputs.metadata_files }}
+
+  validate-json:
+    name: Validate ${{ matrix.file }}
+    needs: [get-modified-files]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: 
+        file: ${{ fromJSON(needs.get-modified-files.outputs.metadata_files) }}
+
+    steps:
+      - name: Checkint out ${{ matrix.file }}
+        uses: actions/checkout@v3  
+
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
+      # Check if the file matches our expected schema
+      - name: Validate ${{ matrix.file }}
+        run: check-jsonschema --schema-file schemas/metadata.schema.json ${{ matrix.file }} --color always
 
   ## Currently not running these as these are very time intensive 
 

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -1,66 +1,80 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-      "code_id": {
-        "type": "integer"
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/CodeMetadata",
+  "definitions": {
+      "CodeMetadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+              "code_id": {
+                  "type": "integer"
+              },
+              "source": {
+                  "$ref": "#/definitions/Source"
+              },
+              "source_builder": {
+                  "$ref": "#/definitions/SourceBuilder"
+              },
+              "schema": {
+                  "type": "string"
+              },
+              "contacts": {
+                  "type": "array",
+                  "items": {
+                      "type": "string"
+                  }
+              }
+          },
+          "required": [
+              "code_id",
+              "schema"
+          ],
+          "title": "CodeMetadata"
       },
-      "source": {
-        "type": "object",
-        "properties": {
-          "repository": {
-            "type": "string"
+      "Source": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+              "repository": {
+                  "type": "string",
+                  "format": "uri",
+                  "qt-uri-protocols": [
+                      "https"
+                  ]
+              },
+              "tag": {
+                  "type": "string"
+              },
+              "license": {
+                  "type": "string"
+              }
           },
-          "tag": {
-            "type": "string"
-          },
-          "license": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "repository",
-          "tag",
-          "license"
-        ]
+          "required": [
+              "repository",
+              "tag"
+          ],
+          "title": "Source"
       },
-      "source_builder": {
-        "type": "object",
-        "properties": {
-          "image": {
-            "type": "string"
+      "SourceBuilder": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+              "image": {
+                  "type": "string"
+              },
+              "tag": {
+                  "type": "string"
+              },
+              "contract_name": {
+                  "type": "string"
+              }
           },
-          "tag": {
-            "type": "string"
-          },
-          "contract_name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "image",
-          "tag",
-          "contract_name"
-        ]
-      },
-      "schema": {
-        "type": "string"
-      },
-      "contacts": {
-        "type": "array",
-        "items": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "required": [
+              "contract_name",
+              "image",
+              "tag"
+          ],
+          "title": "SourceBuilder"
       }
-    },
-    "required": [
-      "code_id",
-      "schema",
-      "contacts"
-    ]
   }
+}


### PR DESCRIPTION
- Previous metadata schema was inaccurate and would accept bad inputs. fixed that
- Changing the schema verification to use the pip package which is better than the gh action which was used before
- Previously all metadata files were validated each PR. now only modified ones are.